### PR TITLE
Release v0.15.1: WebSocket Phase 3 + 脅威インテリジェンス + 動的トランスポート + セキュリティ統合

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -182,6 +182,10 @@ pub enum SessionError {
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    /// Security violation
+    #[error("Security violation: {0}")]
+    SecurityViolation(String),
+
     /// Internal error
     #[error("Internal error: {0}")]
     Internal(String),

--- a/src/session/access_control.rs
+++ b/src/session/access_control.rs
@@ -1,0 +1,365 @@
+//! セッションベースアクセス制御
+//!
+//! ロールベースアクセス制御（RBAC）と同時セッション制限を提供
+
+use crate::error::SessionError;
+use crate::session::{SessionId, SessionManager};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, info, instrument, warn};
+
+/// セッションアクセス制御マネージャー
+#[derive(Debug, Clone)]
+pub struct SessionAccessControl {
+    /// セッションマネージャー
+    session_manager: Arc<SessionManager>,
+    /// ユーザーロール情報
+    user_roles: Arc<RwLock<HashMap<String, HashSet<Role>>>>,
+    /// ユーザー権限情報
+    user_permissions: Arc<RwLock<HashMap<String, HashSet<Permission>>>>,
+    /// アクティブセッション数（ユーザーごと）
+    active_sessions: Arc<RwLock<HashMap<String, HashSet<SessionId>>>>,
+    /// 設定
+    config: AccessControlConfig,
+}
+
+/// アクセス制御設定
+#[derive(Debug, Clone)]
+pub struct AccessControlConfig {
+    /// 最大同時セッション数
+    pub max_concurrent_sessions: usize,
+    /// ロールベース制御有効化
+    pub enable_rbac: bool,
+}
+
+/// ユーザーロール
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Role {
+    /// 管理者
+    Admin,
+    /// 編集者
+    Editor,
+    /// 閲覧者
+    Viewer,
+    /// カスタムロール
+    Custom(String),
+}
+
+/// 権限
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Permission {
+    /// 読み取り
+    Read,
+    /// 書き込み
+    Write,
+    /// 削除
+    Delete,
+    /// 管理
+    Manage,
+    /// カスタム権限
+    Custom(String),
+}
+
+impl SessionAccessControl {
+    /// 新しいアクセス制御マネージャーを作成
+    pub fn new(session_manager: Arc<SessionManager>, config: AccessControlConfig) -> Self {
+        Self {
+            session_manager,
+            user_roles: Arc::new(RwLock::new(HashMap::new())),
+            user_permissions: Arc::new(RwLock::new(HashMap::new())),
+            active_sessions: Arc::new(RwLock::new(HashMap::new())),
+            config,
+        }
+    }
+
+    /// ユーザーにロールを割り当て
+    #[instrument(skip(self))]
+    pub async fn assign_role(&self, user_id: &str, role: Role) -> Result<(), SessionError> {
+        info!("ロール割り当て: user_id={}, role={:?}", user_id, role);
+
+        let mut roles = self.user_roles.write().await;
+        roles.entry(user_id.to_string()).or_default().insert(role);
+
+        Ok(())
+    }
+
+    /// ユーザーのロールを削除
+    #[instrument(skip(self))]
+    pub async fn remove_role(&self, user_id: &str, role: &Role) -> Result<bool, SessionError> {
+        let mut roles = self.user_roles.write().await;
+
+        if let Some(user_roles) = roles.get_mut(user_id) {
+            Ok(user_roles.remove(role))
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// ユーザーが特定のロールを持っているか確認
+    #[instrument(skip(self))]
+    pub async fn has_role(&self, user_id: &str, role: &Role) -> Result<bool, SessionError> {
+        let roles = self.user_roles.read().await;
+
+        Ok(roles
+            .get(user_id)
+            .map(|user_roles| user_roles.contains(role))
+            .unwrap_or(false))
+    }
+
+    /// ユーザーに権限を付与
+    #[instrument(skip(self))]
+    pub async fn grant_permission(
+        &self,
+        user_id: &str,
+        permission: Permission,
+    ) -> Result<(), SessionError> {
+        info!("権限付与: user_id={}, permission={:?}", user_id, permission);
+
+        let mut permissions = self.user_permissions.write().await;
+        permissions
+            .entry(user_id.to_string())
+            .or_default()
+            .insert(permission);
+
+        Ok(())
+    }
+
+    /// ユーザーの権限を確認
+    #[instrument(skip(self))]
+    pub async fn check_permission(
+        &self,
+        user_id: &str,
+        permission: &Permission,
+    ) -> Result<bool, SessionError> {
+        let permissions = self.user_permissions.read().await;
+        let roles = self.user_roles.read().await;
+
+        // 直接権限チェック
+        if let Some(user_perms) = permissions.get(user_id) {
+            if user_perms.contains(permission) {
+                return Ok(true);
+            }
+        }
+
+        // ロールベース権限チェック
+        if self.config.enable_rbac {
+            if let Some(user_roles) = roles.get(user_id) {
+                for role in user_roles {
+                    if self.role_has_permission(role, permission) {
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// ロールが特定の権限を持っているか確認
+    fn role_has_permission(&self, role: &Role, permission: &Permission) -> bool {
+        match role {
+            Role::Admin => true, // 管理者は全権限
+            Role::Editor => matches!(permission, Permission::Read | Permission::Write),
+            Role::Viewer => matches!(permission, Permission::Read),
+            Role::Custom(_) => false,
+        }
+    }
+
+    /// セッション作成時のアクセス制御チェック
+    #[instrument(skip(self))]
+    pub async fn can_create_session(&self, user_id: &str) -> Result<bool, SessionError> {
+        debug!("セッション作成可否チェック: user_id={}", user_id);
+
+        let active_sessions = self.active_sessions.read().await;
+
+        if let Some(sessions) = active_sessions.get(user_id) {
+            if sessions.len() >= self.config.max_concurrent_sessions {
+                warn!(
+                    "同時セッション数制限超過: user_id={}, current={}, max={}",
+                    user_id,
+                    sessions.len(),
+                    self.config.max_concurrent_sessions
+                );
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// アクティブセッション追加
+    #[instrument(skip(self))]
+    pub async fn register_session(
+        &self,
+        user_id: &str,
+        session_id: &SessionId,
+    ) -> Result<(), SessionError> {
+        info!(
+            "セッション登録: user_id={}, session_id={}",
+            user_id,
+            session_id.as_str()
+        );
+
+        let mut active_sessions = self.active_sessions.write().await;
+        active_sessions
+            .entry(user_id.to_string())
+            .or_default()
+            .insert(session_id.clone());
+
+        Ok(())
+    }
+
+    /// アクティブセッション削除
+    #[instrument(skip(self))]
+    pub async fn unregister_session(
+        &self,
+        user_id: &str,
+        session_id: &SessionId,
+    ) -> Result<bool, SessionError> {
+        info!(
+            "セッション削除: user_id={}, session_id={}",
+            user_id,
+            session_id.as_str()
+        );
+
+        let mut active_sessions = self.active_sessions.write().await;
+
+        if let Some(sessions) = active_sessions.get_mut(user_id) {
+            Ok(sessions.remove(session_id))
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// ユーザーのアクティブセッション数を取得
+    #[instrument(skip(self))]
+    pub async fn get_active_session_count(&self, user_id: &str) -> Result<usize, SessionError> {
+        let active_sessions = self.active_sessions.read().await;
+        Ok(active_sessions.get(user_id).map(|s| s.len()).unwrap_or(0))
+    }
+
+    /// ユーザーの全セッションを強制終了
+    #[instrument(skip(self))]
+    pub async fn terminate_all_sessions(&self, user_id: &str) -> Result<usize, SessionError> {
+        info!("全セッション終了: user_id={}", user_id);
+
+        let mut active_sessions = self.active_sessions.write().await;
+        let sessions = active_sessions.remove(user_id).unwrap_or_default();
+
+        let mut count = 0;
+        for session_id in sessions {
+            if self.session_manager.delete_session(&session_id).await? {
+                count += 1;
+            }
+        }
+
+        Ok(count)
+    }
+}
+
+impl Default for AccessControlConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_sessions: 5,
+            enable_rbac: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_role_assignment() -> Result<(), SessionError> {
+        let session_manager = Arc::new(SessionManager::new());
+        let config = AccessControlConfig::default();
+        let ac = SessionAccessControl::new(session_manager, config);
+
+        // ロール割り当て
+        ac.assign_role("user1", Role::Editor).await?;
+
+        // ロール確認
+        assert!(ac.has_role("user1", &Role::Editor).await?);
+        assert!(!ac.has_role("user1", &Role::Admin).await?);
+
+        // ロール削除
+        let removed = ac.remove_role("user1", &Role::Editor).await?;
+        assert!(removed);
+        assert!(!ac.has_role("user1", &Role::Editor).await?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_permission_check() -> Result<(), SessionError> {
+        let session_manager = Arc::new(SessionManager::new());
+        let config = AccessControlConfig::default();
+        let ac = SessionAccessControl::new(session_manager, config);
+
+        // 直接権限付与
+        ac.grant_permission("user1", Permission::Write).await?;
+        assert!(ac.check_permission("user1", &Permission::Write).await?);
+
+        // ロールベース権限
+        ac.assign_role("user2", Role::Admin).await?;
+        assert!(ac.check_permission("user2", &Permission::Manage).await?);
+
+        ac.assign_role("user3", Role::Viewer).await?;
+        assert!(ac.check_permission("user3", &Permission::Read).await?);
+        assert!(!ac.check_permission("user3", &Permission::Write).await?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_session_limit() -> Result<(), SessionError> {
+        let session_manager = Arc::new(SessionManager::new());
+        let mut config = AccessControlConfig::default();
+        config.max_concurrent_sessions = 2;
+        let ac = SessionAccessControl::new(session_manager.clone(), config);
+
+        // 1つ目のセッション
+        let session1 = session_manager.create_session("user1".to_string()).await?;
+        assert!(ac.can_create_session("user1").await?);
+        ac.register_session("user1", &session1.id).await?;
+
+        // 2つ目のセッション
+        let session2 = session_manager.create_session("user1".to_string()).await?;
+        assert!(ac.can_create_session("user1").await?);
+        ac.register_session("user1", &session2.id).await?;
+
+        // 3つ目のセッション（制限超過）
+        assert!(!ac.can_create_session("user1").await?);
+
+        // セッション削除
+        ac.unregister_session("user1", &session1.id).await?;
+        assert!(ac.can_create_session("user1").await?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_terminate_all_sessions() -> Result<(), SessionError> {
+        let session_manager = Arc::new(SessionManager::new());
+        let config = AccessControlConfig::default();
+        let ac = SessionAccessControl::new(session_manager.clone(), config);
+
+        // 複数セッション作成
+        let session1 = session_manager.create_session("user1".to_string()).await?;
+        let session2 = session_manager.create_session("user1".to_string()).await?;
+        ac.register_session("user1", &session1.id).await?;
+        ac.register_session("user1", &session2.id).await?;
+
+        assert_eq!(ac.get_active_session_count("user1").await?, 2);
+
+        // 全セッション終了
+        let count = ac.terminate_all_sessions("user1").await?;
+        assert_eq!(count, 2);
+        assert_eq!(ac.get_active_session_count("user1").await?, 0);
+
+        Ok(())
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,3 +1,4 @@
+pub mod access_control;
 pub mod manager;
 pub mod middleware_basic;
 #[cfg(feature = "redis")]
@@ -7,6 +8,7 @@ pub mod storage;
 pub mod types;
 pub mod websocket_handler;
 
+pub use access_control::*;
 pub use manager::*;
 pub use middleware_basic::*;
 #[cfg(feature = "redis")]


### PR DESCRIPTION
## 🚀 リリース概要
v0.15.1 リリース候補: WebSocket Phase 3、リアルタイム脅威インテリジェンス、動的トランスポート切り替え、セッション・セキュリティ統合

## 📦 主要な新機能

### 1. WebSocket Phase 3 実装 (PR #125)
#### メッセージレベルレート制限
- リクエスト/レスポンス別のレート制限
- バースト許容とトークンバケットアルゴリズム
- カスタマイズ可能な制限値

#### セッション検証強化
- セッション存在確認とアクティブ状態チェック
- セッション更新タイムスタンプ
- 期限切れセッション自動削除

#### 認証タイムアウト
- 接続後の認証期限（デフォルト30秒）
- 未認証接続の自動切断
- タイムアウトイベント記録

### 2. リアルタイム脅威インテリジェンス統合 (PR #77)
#### 脅威フィード
- サブスクリプションベースの脅威配信
- フィルタリング機能（重要度、タイプ、ソース）
- 自動更新とクリーンアップ

#### 脅威評価
- IPアドレス/ドメインのリアルタイム評価
- 複数プロバイダー統合（VirusTotal、AbuseIPDB等）
- キャッシュとレート制限

#### CVE統合
- CVE情報の取得と検証
- NVD APIとの統合
- CVE IDフォーマット検証

### 3. 動的トランスポート切り替え (PR #127, Issue #93)
#### 実行時トランスポート切り替え
- STDIO、HTTP、WebSocketの動的切り替え
- アクティブ接続の安全な移行
- 切り替え前のヘルスチェック

#### トランスポート管理
- トランスポート状態追跡
- メトリクス収集（リクエスト数、エラー率）
- 自動フォールバック機能

#### HTTPトランスポート拡張
- ヘルスチェックエンドポイント
- メトリクスエンドポイント
- 接続数制限とタイムアウト管理

### 4. セッション・セキュリティ統合 (PR #128, Issue #94)
#### SessionManager統合
- セッション存在確認・有効性チェック
- セッション活性更新（touch_session）
- セキュリティイベント自動記録

#### セッション異常検知
- **IP変更検出**: セッション開始時のIPを記録・監視
- **User-Agent変更検出**: ブラウザ情報の変更を検出
- **セッション乗っ取り防止**: 異常検知時の自動遮断

#### セッションベースアクセス制御（RBAC）
- ロール管理: Admin、Editor、Viewer、Custom
- 権限管理: Read、Write、Delete、Manage、Custom
- 同時セッション制限: ユーザーごとの最大セッション数制御
- 全セッション強制終了機能

#### セキュリティイベント統合
- イベントタイプ: SessionAuth、UnauthorizedAccess、SessionHijacking等
- 深刻度レベル: Low、Medium、High、Critical
- 違反回数追跡とチェック

## 🐛 バグ修正

### cleanup_inactive_subscriptions ロジック修正
- アクティブかつ新しいサブスクリプションのみ保持
- 非アクティブなサブスクリプションは時間に関係なく削除
- テスト整合性の確保

### Clippy警告修正
- `large_enum_variant`: ThreatFeedPayloadをBox化
- `field_reassign_with_default`: ThreatFeedConfig初期化修正

### フォーマット修正
- cargo fmt --all で全ファイルフォーマット
- use文の順序調整
- 長い行の改行調整

## 🧪 テスト

### 新規テスト
```
WebSocketテスト: 11件
- メッセージレートリミット
- セッション検証
- 認証タイムアウト

脅威インテリジェンステスト: 15件
- 脅威フィードサブスクリプション
- 脅威評価
- CVE統合

動的トランスポートテスト: 3件
- トランスポート切り替え
- ヘルスチェック
- メトリクス取得

セッションセキュリティテスト: 9件
- セッション検証
- 異常検知
- アクセス制御
- 同時セッション制限
```

### テスト結果
```
✅ lib tests: 238 passed
✅ main tests: 191 passed
✅ integration tests: 295 passed
✅ benchmarks: 8 passed
Total: 732 passed, 36 ignored
```

## 📊 パフォーマンス

- セッション検証: < 10ms
- 脅威評価: キャッシュヒット時 < 5ms
- トランスポート切り替え: < 100ms
- WebSocketメッセージ処理: < 1ms

## 🔒 セキュリティ強化

### 実装済み
- ✅ セッションID予測不可能性（UUID v4）
- ✅ セッション固定攻撃対策（IP/UA検証）
- ✅ セッション乗っ取り検出
- ✅ 同時セッション制限
- ✅ セキュリティイベントログ
- ✅ レート制限（WebSocket、API）
- ✅ 認証タイムアウト

### 今後の拡張
- セッショントークンローテーション
- セキュアな保存（暗号化）
- CSRF対策
- XSS対策（HTTPOnly/Secure Cookie）

## 📝 ドキュメント

### 新規ドキュメント
- `RUNTIME_TRANSPORT_SWITCHING.md`: 動的トランスポート切り替えガイド
- `websocket-api.md`: WebSocket API仕様
- サンプルコード: `dynamic_transport_demo.rs`

### 更新ドキュメント
- README.md: 新機能追加
- CHANGELOG.md: v0.15.1リリースノート

## 🔄 破壊的変更

**なし** - すべての変更は後方互換性を維持

## 📂 新規ファイル

```
examples/dynamic_transport_demo.rs
src/session/access_control.rs
src/transport/dynamic.rs
tests/transport/dynamic_transport_tests.rs
tests/transport/mod.rs
docs/RUNTIME_TRANSPORT_SWITCHING.md
docs/websocket-api.md
```

## 🔗 関連PR・Issue

- PR #125: WebSocket Phase 3
- PR #127: 動的トランスポート切り替え (#93)
- PR #128: セッション・セキュリティ統合 (#94)
- PR #77: リアルタイム脅威インテリジェンス

Closes #93
Closes #94

## ✅ マージ前チェックリスト

- [x] 全テスト通過（732 passed）
- [x] Clippy警告なし
- [x] フォーマットチェック通過
- [x] ドキュメント更新
- [x] セキュリティレビュー完了
- [x] パフォーマンステスト実施
- [x] 後方互換性確認