### PR TITLE
fix(docker): Dockerfileバイナリ名修正 (develop → main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY tests ./tests
 COPY configs ./configs
 
 # Build release binary
-RUN cargo build --release --bin mcp-rs-server
+RUN cargo build --release --bin mcp-rs
 
 # Stage 2: Runtime
 FROM debian:bullseye-slim
@@ -54,13 +54,13 @@ RUN mkdir -p /app/configs /app/logs /var/log/mcp-rs && \
 WORKDIR /app
 
 # Copy binary from builder
-COPY --from=builder /app/target/release/mcp-rs-server /usr/local/bin/mcp-rs-server
+COPY --from=builder /app/target/release/mcp-rs /usr/local/bin/mcp-rs
 
 # Copy configuration files
 COPY --from=builder /app/configs /app/configs
 
 # Set permissions
-RUN chmod +x /usr/local/bin/mcp-rs-server && \
+RUN chmod +x /usr/local/bin/mcp-rs && \
     chown -R mcp:mcp /app
 
 # Switch to non-root user
@@ -79,4 +79,4 @@ ENV RUST_LOG=info \
     MCP_CONFIG_PATH=/app/configs/production/main.toml
 
 # Run the application
-CMD ["mcp-rs-server", "--config", "/app/configs/production/main.toml"]
+CMD ["mcp-rs", "--config", "/app/configs/production/main.toml"]


### PR DESCRIPTION
## 概要
Dockerビルドエラーを修正するため、バイナリ名を`mcp-rs-server`から正しい`mcp-rs`に変更しました。

## 変更内容
- ✅ `cargo build --release --bin mcp-rs-server` → `--bin mcp-rs`
- ✅ COPYコマンドのパス修正: `/app/target/release/mcp-rs-server` → `/app/target/release/mcp-rs`
- ✅ 実行ファイルパス修正: `/usr/local/bin/mcp-rs-server` → `/usr/local/bin/mcp-rs`
- ✅ CMDコマンド修正: `["mcp-rs-server", ...]` → `["mcp-rs", ...]`

## エラー原因
```
error: no bin target named `mcp-rs-server` in default-run packages
help: available bin targets:
    mcp-rs
    performance_test_execution_analysis
```

Cargo.tomlで定義されているバイナリ名は`mcp-rs`ですが、Dockerfileでは誤って`mcp-rs-server`を指定していました。

## 影響範囲
- Dockerビルドプロセス
- 本番環境デプロイメント

## テスト
- [ ] ローカルDockerビルド確認
- [ ] マルチアーキテクチャビルド確認

## チェックリスト
- [x] コード修正完了
- [x] コミットメッセージ適切
- [ ] CI/CD通過確認

## 関連Issue
Docker buildエラー修正

---
**マージ後のアクション**: 本番環境へのデプロイ前に、Dockerイメージのビルドとテストを実施してください。