### PR TITLE
refactor: Split transport module into focused modules (#166)

### DIFF
--- a/src/transport/config.rs
+++ b/src/transport/config.rs
@@ -1,0 +1,27 @@
+//! Transport Configuration
+//!
+//! Configuration types for transport setup
+
+use serde::{Deserialize, Serialize};
+
+use super::http;
+use super::stdio;
+use super::types::TransportType;
+
+/// Transport configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransportConfig {
+    pub transport_type: TransportType,
+    pub stdio: stdio::StdioConfig,
+    pub http: http::HttpConfig,
+}
+
+impl Default for TransportConfig {
+    fn default() -> Self {
+        Self {
+            transport_type: TransportType::Stdio,
+            stdio: stdio::StdioConfig::default(),
+            http: http::HttpConfig::default(),
+        }
+    }
+}

--- a/src/transport/error.rs
+++ b/src/transport/error.rs
@@ -1,0 +1,53 @@
+//! Transport Errors
+//!
+//! Error types for transport operations
+
+use std::fmt;
+use thiserror::Error;
+
+/// Transport-specific error types
+#[derive(Debug, Error)]
+pub enum TransportError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Message parsing error: {0}")]
+    Parse(#[from] serde_json::Error),
+
+    #[error("Protocol error: {0}")]
+    Protocol(String),
+
+    #[error("Connection closed")]
+    ConnectionClosed,
+
+    #[error("Timeout: {0}")]
+    Timeout(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+
+    #[error("Configuration error: {0}")]
+    Configuration(String),
+
+    #[error("Transport not supported: {0}")]
+    NotSupported(String),
+
+    #[error("Buffer overflow: message too large")]
+    BufferOverflow,
+
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
+}
+
+impl From<crate::error::Error> for TransportError {
+    fn from(err: crate::error::Error) -> Self {
+        match err {
+            crate::error::Error::Io(e) => TransportError::Io(e),
+            crate::error::Error::Parse(e) => TransportError::Internal(e),
+            crate::error::Error::Config(e) => TransportError::Configuration(e),
+            crate::error::Error::Internal(e) => TransportError::Internal(e),
+            crate::error::Error::NotSupported(e) => TransportError::NotSupported(e),
+            _ => TransportError::Internal(format!("Converted error: {}", err)),
+        }
+    }
+}

--- a/src/transport/factory.rs
+++ b/src/transport/factory.rs
@@ -2,12 +2,12 @@
 //!
 //! Factory for creating transport instances
 
+use super::config::TransportConfig;
 use super::error::TransportError;
 use super::http;
 use super::stdio;
 use super::transport_trait::Transport;
 use super::types::TransportType;
-use super::config::TransportConfig;
 
 /// Transport factory for creating transport instances
 pub struct TransportFactory;

--- a/src/transport/factory.rs
+++ b/src/transport/factory.rs
@@ -1,0 +1,39 @@
+//! Transport Factory
+//!
+//! Factory for creating transport instances
+
+use super::error::TransportError;
+use super::http;
+use super::stdio;
+use super::transport_trait::Transport;
+use super::types::TransportType;
+use super::config::TransportConfig;
+
+/// Transport factory for creating transport instances
+pub struct TransportFactory;
+
+impl TransportFactory {
+    /// Create a transport instance based on configuration
+    pub fn create_transport(
+        config: &TransportConfig,
+    ) -> std::result::Result<Box<dyn Transport<Error = TransportError>>, TransportError> {
+        match &config.transport_type {
+            TransportType::Stdio => {
+                let stdio_transport = stdio::StdioTransport::new(config.stdio.clone())?;
+                Ok(Box::new(stdio_transport))
+            }
+            TransportType::Http { addr } => {
+                let http_config = http::HttpConfig {
+                    bind_addr: *addr,
+                    ..Default::default()
+                };
+                let http_transport = http::HttpTransport::new(http_config)
+                    .map_err(|e| TransportError::Internal(e.to_string()))?;
+                Ok(Box::new(http_transport))
+            }
+            TransportType::WebSocket { .. } => Err(TransportError::NotSupported(
+                "WebSocket transport not yet implemented".to_string(),
+            )),
+        }
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -6,208 +6,27 @@
 //! Each transport implements the Transport trait to provide consistent
 //! message handling across different communication channels.
 
+pub mod config;
 pub mod connection;
 pub mod dynamic;
+pub mod error;
+pub mod factory;
 pub mod http;
 pub mod stdio;
+pub mod transport_trait;
+pub mod types;
 pub mod websocket;
 
-use crate::{
-    error::Result,
-    types::{JsonRpcRequest, JsonRpcResponse},
-};
-use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-use std::fmt;
-use thiserror::Error;
-
+pub use config::TransportConfig;
 pub use connection::{ConnectionInfo, ConnectionStats};
 pub use dynamic::{DynamicTransportManager, TransportSwitcher};
+pub use error::TransportError;
+pub use factory::TransportFactory;
 pub use http::{HttpConfig, HttpTransport};
 pub use stdio::{StdioConfig, StdioTransport};
+pub use transport_trait::Transport;
+pub use types::{FramingMethod, TransportCapabilities, TransportInfo, TransportType};
 pub use websocket::{WebSocketConfig, WebSocketTransport};
-
-/// Transport layer abstraction for MCP communication
-#[async_trait]
-pub trait Transport: Send + Sync + fmt::Debug {
-    type Error: std::error::Error + Send + Sync + 'static;
-
-    /// Start the transport and begin listening for connections
-    async fn start(&mut self) -> std::result::Result<(), Self::Error>;
-
-    /// Stop the transport and close all connections
-    async fn stop(&mut self) -> std::result::Result<(), Self::Error>;
-
-    /// Send a JSON-RPC response message
-    async fn send_message(
-        &mut self,
-        message: JsonRpcResponse,
-    ) -> std::result::Result<(), Self::Error>;
-
-    /// Receive a JSON-RPC request message (non-blocking)
-    async fn receive_message(&mut self)
-        -> std::result::Result<Option<JsonRpcRequest>, Self::Error>;
-
-    /// Check if the transport is currently connected/active
-    fn is_connected(&self) -> bool;
-
-    /// Get transport information and capabilities
-    fn transport_info(&self) -> TransportInfo;
-
-    /// Get current connection statistics
-    fn connection_stats(&self) -> ConnectionStats;
-}
-
-/// Information about a transport implementation
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransportInfo {
-    pub transport_type: TransportType,
-    pub description: String,
-    pub capabilities: TransportCapabilities,
-}
-
-/// Types of supported transports
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum TransportType {
-    /// Standard input/output transport
-    Stdio,
-    /// HTTP server transport
-    Http { addr: std::net::SocketAddr },
-    /// WebSocket transport
-    WebSocket { url: String },
-}
-
-/// Transport-specific capabilities
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransportCapabilities {
-    /// Supports bidirectional communication
-    pub bidirectional: bool,
-    /// Supports connection multiplexing
-    pub multiplexing: bool,
-    /// Supports message compression
-    pub compression: bool,
-    /// Maximum message size (bytes)
-    pub max_message_size: Option<usize>,
-    /// Supported framing methods
-    pub framing_methods: Vec<FramingMethod>,
-}
-
-/// Message framing methods
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum FramingMethod {
-    /// Content-Length header followed by JSON
-    ContentLength,
-    /// Line-based JSON messages
-    LineBased,
-    /// WebSocket frame-based
-    WebSocketFrame,
-}
-
-// Use ConnectionStats from connection module
-
-/// Transport-specific error types
-#[derive(Debug, Error)]
-pub enum TransportError {
-    #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
-
-    #[error("Message parsing error: {0}")]
-    Parse(#[from] serde_json::Error),
-
-    #[error("Protocol error: {0}")]
-    Protocol(String),
-
-    #[error("Connection closed")]
-    ConnectionClosed,
-
-    #[error("Timeout: {0}")]
-    Timeout(String),
-
-    #[error("Internal error: {0}")]
-    Internal(String),
-
-    #[error("Configuration error: {0}")]
-    Configuration(String),
-
-    #[error("Transport not supported: {0}")]
-    NotSupported(String),
-
-    #[error("Buffer overflow: message too large")]
-    BufferOverflow,
-
-    #[error("Unauthorized: {0}")]
-    Unauthorized(String),
-}
-
-impl From<crate::error::Error> for TransportError {
-    fn from(err: crate::error::Error) -> Self {
-        match err {
-            crate::error::Error::Io(e) => TransportError::Io(e),
-            crate::error::Error::Parse(e) => TransportError::Internal(e),
-            crate::error::Error::Config(e) => TransportError::Configuration(e),
-            crate::error::Error::Internal(e) => TransportError::Internal(e),
-            crate::error::Error::NotSupported(e) => TransportError::NotSupported(e),
-            _ => TransportError::Internal(format!("Converted error: {}", err)),
-        }
-    }
-}
-
-impl fmt::Display for TransportType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            TransportType::Stdio => write!(f, "stdio"),
-            TransportType::Http { addr } => write!(f, "http://{}", addr),
-            TransportType::WebSocket { url } => write!(f, "ws://{}", url),
-        }
-    }
-}
-
-/// Transport factory for creating transport instances
-pub struct TransportFactory;
-
-impl TransportFactory {
-    /// Create a transport instance based on configuration
-    pub fn create_transport(
-        config: &TransportConfig,
-    ) -> std::result::Result<Box<dyn Transport<Error = TransportError>>, TransportError> {
-        match &config.transport_type {
-            TransportType::Stdio => {
-                let stdio_transport = stdio::StdioTransport::new(config.stdio.clone())?;
-                Ok(Box::new(stdio_transport))
-            }
-            TransportType::Http { addr } => {
-                let http_config = http::HttpConfig {
-                    bind_addr: *addr,
-                    ..Default::default()
-                };
-                let http_transport = http::HttpTransport::new(http_config)
-                    .map_err(|e| TransportError::Internal(e.to_string()))?;
-                Ok(Box::new(http_transport))
-            }
-            TransportType::WebSocket { .. } => Err(TransportError::NotSupported(
-                "WebSocket transport not yet implemented".to_string(),
-            )),
-        }
-    }
-}
-
-/// Transport configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransportConfig {
-    pub transport_type: TransportType,
-    pub stdio: stdio::StdioConfig,
-    pub http: http::HttpConfig,
-}
-
-impl Default for TransportConfig {
-    fn default() -> Self {
-        Self {
-            transport_type: TransportType::Stdio,
-            stdio: stdio::StdioConfig::default(),
-            http: http::HttpConfig::default(),
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -253,8 +72,6 @@ mod tests {
         assert_eq!(stats.messages_received, 0);
         assert_eq!(stats.bytes_sent, 0);
         assert_eq!(stats.bytes_received, 0);
-        // connection_errors フィールドは存在しないためコメントアウト
-        // assert_eq!(stats.connection_errors, 0);
         assert!(stats.last_activity.is_none());
     }
 }

--- a/src/transport/transport_trait.rs
+++ b/src/transport/transport_trait.rs
@@ -1,0 +1,42 @@
+//! Transport Trait
+//!
+//! Core trait for all transport implementations
+
+use crate::types::{JsonRpcRequest, JsonRpcResponse};
+use async_trait::async_trait;
+use std::fmt;
+
+use super::connection::ConnectionStats;
+use super::types::TransportInfo;
+
+/// Transport layer abstraction for MCP communication
+#[async_trait]
+pub trait Transport: Send + Sync + fmt::Debug {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Start the transport and begin listening for connections
+    async fn start(&mut self) -> std::result::Result<(), Self::Error>;
+
+    /// Stop the transport and close all connections
+    async fn stop(&mut self) -> std::result::Result<(), Self::Error>;
+
+    /// Send a JSON-RPC response message
+    async fn send_message(
+        &mut self,
+        message: JsonRpcResponse,
+    ) -> std::result::Result<(), Self::Error>;
+
+    /// Receive a JSON-RPC request message (non-blocking)
+    async fn receive_message(
+        &mut self,
+    ) -> std::result::Result<Option<JsonRpcRequest>, Self::Error>;
+
+    /// Check if the transport is currently connected/active
+    fn is_connected(&self) -> bool;
+
+    /// Get transport information and capabilities
+    fn transport_info(&self) -> TransportInfo;
+
+    /// Get current connection statistics
+    fn connection_stats(&self) -> ConnectionStats;
+}

--- a/src/transport/transport_trait.rs
+++ b/src/transport/transport_trait.rs
@@ -27,9 +27,8 @@ pub trait Transport: Send + Sync + fmt::Debug {
     ) -> std::result::Result<(), Self::Error>;
 
     /// Receive a JSON-RPC request message (non-blocking)
-    async fn receive_message(
-        &mut self,
-    ) -> std::result::Result<Option<JsonRpcRequest>, Self::Error>;
+    async fn receive_message(&mut self)
+        -> std::result::Result<Option<JsonRpcRequest>, Self::Error>;
 
     /// Check if the transport is currently connected/active
     fn is_connected(&self) -> bool;

--- a/src/transport/types.rs
+++ b/src/transport/types.rs
@@ -1,0 +1,61 @@
+//! Transport Types
+//!
+//! Common types for transport implementations
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Information about a transport implementation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransportInfo {
+    pub transport_type: TransportType,
+    pub description: String,
+    pub capabilities: TransportCapabilities,
+}
+
+/// Types of supported transports
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum TransportType {
+    /// Standard input/output transport
+    Stdio,
+    /// HTTP server transport
+    Http { addr: std::net::SocketAddr },
+    /// WebSocket transport
+    WebSocket { url: String },
+}
+
+/// Transport-specific capabilities
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransportCapabilities {
+    /// Supports bidirectional communication
+    pub bidirectional: bool,
+    /// Supports connection multiplexing
+    pub multiplexing: bool,
+    /// Supports message compression
+    pub compression: bool,
+    /// Maximum message size (bytes)
+    pub max_message_size: Option<usize>,
+    /// Supported framing methods
+    pub framing_methods: Vec<FramingMethod>,
+}
+
+/// Message framing methods
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FramingMethod {
+    /// Content-Length header followed by JSON
+    ContentLength,
+    /// Line-based JSON messages
+    LineBased,
+    /// WebSocket frame-based
+    WebSocketFrame,
+}
+
+impl fmt::Display for TransportType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransportType::Stdio => write!(f, "stdio"),
+            TransportType::Http { addr } => write!(f, "http://{}", addr),
+            TransportType::WebSocket { url } => write!(f, "ws://{}", url),
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Issue #166 - `transport/mod.rs`のアンチパターン解消

## 変更内容
### 分割構造
- **types.rs** (62行): 型定義
  - `TransportInfo`, `TransportType`
  - `TransportCapabilities`, `FramingMethod`
  - `TransportType` の `Display` 実装
- **transport_trait.rs** (42行): トレイト定義
  - `Transport` トレイト
- **error.rs** (55行): エラー型
  - `TransportError` 列挙型
  - `crate::error::Error` からの変換実装
- **config.rs** (27行): 設定
  - `TransportConfig` + `Default` 実装
- **factory.rs** (39行): ファクトリー
  - `TransportFactory` 実装
- **mod.rs** (87行): 再エクスポート + テスト

### 既存サブモジュール
以下は変更なし（そのまま保持）:
- `connection/`
- `dynamic/`
- `http/`
- `stdio/`
- `websocket/`

## テスト結果
✅ **全377テスト成功**
```
test result: ok. 377 passed; 0 failed; 1 ignored; 0 measured
```

✅ **Clippy警告なし**
```
cargo clippy --all-targets --all-features -- -D warnings
Finished `dev` profile
```

## 破壊的変更
なし - Public APIは完全に保持

## 関連Issue
Closes #166

## チェックリスト
- [x] 全テスト成功 (377/377)
- [x] Clippy警告なし
- [x] Public API変更なし
- [x] ドキュメントコメント保持
- [x] 既存サブモジュール保持