### PR TITLE
feat(security): complete #225 E2E encryption key exchange flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +791,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1616,7 +1641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2436,7 +2461,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2699,7 +2724,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3229,11 +3254,13 @@ dependencies = [
  "base64 0.22.1",
  "bollard",
  "brotli",
+ "chacha20poly1305",
  "chrono",
  "clap",
  "config",
  "criterion",
  "crossterm",
+ "ed25519-dalek",
  "env_logger",
  "eventsource-stream",
  "fancy-regex 0.16.2",
@@ -3305,6 +3332,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "validator",
+ "x25519-dalek",
  "x509-parser",
  "zeroize",
  "zstd",
@@ -4241,6 +4269,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4503,7 +4542,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4540,9 +4579,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4950,7 +4989,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5905,7 +5944,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6858,7 +6897,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7189,6 +7228,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7295,6 +7346,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,11 @@ base64 = "0.22.1"
 secrecy = { version = "0.10.3", features = ["serde"] }
 zeroize = "1.8.2"
 aes-gcm = "0.10"
+chacha20poly1305 = "0.10"
 pbkdf2 = "0.12"
 sha2 = "0.10"
+ed25519-dalek = "2.1"
+x25519-dalek = { version = "2.0", features = ["static_secrets"] }
 
 # mTLS and Certificate Management
 rcgen = { version = "0.13", features = ["pem", "x509-parser"] }

--- a/src/plugin_isolation/communication_broker.rs
+++ b/src/plugin_isolation/communication_broker.rs
@@ -11,7 +11,16 @@ use tokio::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use chacha20poly1305::aead::Aead;
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit, Nonce};
+use ed25519_dalek::SigningKey;
+use ring::rand::{SecureRandom, SystemRandom};
+use ring::{digest, hmac};
+use x25519_dalek::{PublicKey, StaticSecret};
+
 use crate::error::McpError;
+use crate::plugin_isolation::key_exchange::{KeyExchangeConfig, KeyExchangeProtocol};
 use crate::plugin_isolation::PluginState;
 
 /// 通信ブローカー
@@ -23,12 +32,17 @@ pub struct CommunicationBroker {
     message_filters: Arc<MessageFilterEngine>,
     /// レート制限管理
     rate_limiters: Arc<RwLock<HashMap<Uuid, RateLimiter>>>,
-    /// 暗号化マネージャー
+    /// 暗号化マネージャー（BrokerMessage トランスポート層暗号化）
     encryption_manager: Arc<EncryptionManager>,
     /// 認証マネージャー
     auth_manager: Arc<AuthenticationManager>,
     /// メッセージキュー
     message_queue: Arc<MessageQueue>,
+    /// プラグイン間 E2E 鍵交換プロトコル
+    ///
+    /// プラグイン同士が直接 ECDH 鍵交換を行い [`EncryptedPayload`] で
+    /// エンドツーエンド暗号化通信するための専用コンポーネント。
+    pub key_exchange_protocol: Arc<KeyExchangeProtocol>,
     /// 設定
     config: BrokerConfig,
 }
@@ -104,6 +118,10 @@ pub struct AuthenticationInfo {
     pub certificate: Option<Vec<u8>>,
     /// 公開鍵
     pub public_key: Vec<u8>,
+    /// 署名検証用公開鍵
+    pub signing_public_key: Vec<u8>,
+    /// 鍵識別子
+    pub key_id: String,
     /// 有効期限
     pub expires_at: chrono::DateTime<chrono::Utc>,
     /// 権限
@@ -531,6 +549,15 @@ impl CommunicationBroker {
         let encryption_manager = Arc::new(EncryptionManager::new(&config.encryption_config).await?);
         let auth_manager = Arc::new(AuthenticationManager::new(config.auth_config.clone()).await?);
         let message_queue = Arc::new(MessageQueue::new(config.queue_config.clone()).await?);
+        let kex_config = KeyExchangeConfig {
+            key_lifetime_hours: config.encryption_config.key_rotation.rotation_interval_hours,
+            grace_period_hours: config.encryption_config.key_rotation.overlap_hours,
+            message_ttl_secs: 300,
+        };
+        let key_exchange_protocol = Arc::new(KeyExchangeProtocol::new_with_config(kex_config));
+        if config.encryption_config.key_rotation.auto_rotation_enabled {
+            KeyExchangeProtocol::start_auto_rotation(Arc::clone(&key_exchange_protocol));
+        }
 
         Ok(Self {
             active_channels: Arc::new(RwLock::new(HashMap::new())),
@@ -539,6 +566,7 @@ impl CommunicationBroker {
             encryption_manager,
             auth_manager,
             message_queue,
+            key_exchange_protocol,
             config,
         })
     }
@@ -568,6 +596,11 @@ impl CommunicationBroker {
         let auth_info = self
             .auth_manager
             .generate_authentication_info(plugin_id)
+            .await?;
+
+        // E2E 鍵交換プロトコルにプラグインを登録
+        self.key_exchange_protocol
+            .register_plugin(plugin_id)
             .await?;
 
         // 暗号化設定を生成
@@ -637,6 +670,9 @@ impl CommunicationBroker {
 
         // 認証情報を削除
         self.auth_manager.revoke_plugin_tokens(plugin_id).await?;
+
+        // E2E 鍵交換プロトコルからプラグインを削除
+        self.key_exchange_protocol.unregister_plugin(plugin_id).await;
 
         info!("Communication channel unregistered: {}", plugin_id);
         Ok(())
@@ -806,16 +842,11 @@ impl RateLimiter {
 }
 
 impl EncryptionManager {
-    async fn new(_config: &EncryptionConfig) -> Result<Self, McpError> {
-        // TODO: 実装
+    async fn new(config: &EncryptionConfig) -> Result<Self, McpError> {
         Ok(Self {
             key_manager: Arc::new(KeyManager {
                 active_keys: Arc::new(RwLock::new(HashMap::new())),
-                rotation_config: KeyRotationConfig {
-                    rotation_interval_hours: 24,
-                    auto_rotation_enabled: true,
-                    overlap_hours: 1,
-                },
+                rotation_config: config.key_rotation.clone(),
             }),
             encryption_engines: HashMap::new(),
         })
@@ -823,25 +854,141 @@ impl EncryptionManager {
 
     async fn generate_channel_encryption(
         &self,
-        _plugin_id: Uuid,
+        plugin_id: Uuid,
     ) -> Result<ChannelEncryption, McpError> {
-        // TODO: 実装
+        let rng = SystemRandom::new();
+        let mut key = vec![0u8; 32];
+        let mut iv = vec![0u8; 12];
+        let mut signing_key = vec![0u8; 32];
+
+        rng.fill(&mut key)
+            .map_err(|e| McpError::SecurityFailure(format!("Failed to generate channel key: {e}")))?;
+        rng.fill(&mut iv)
+            .map_err(|e| McpError::SecurityFailure(format!("Failed to generate channel nonce: {e}")))?;
+        rng.fill(&mut signing_key)
+            .map_err(|e| McpError::SecurityFailure(format!("Failed to generate signing key: {e}")))?;
+
+        let now = chrono::Utc::now();
+        let expires_at = now
+            + chrono::Duration::hours(self.key_manager.rotation_config.rotation_interval_hours as i64);
+        let mut active_keys = self.key_manager.active_keys.write().await;
+        active_keys.insert(
+            plugin_id,
+            EncryptionKeys {
+                primary_key: key.clone(),
+                secondary_key: None,
+                signing_key: signing_key.clone(),
+                created_at: now,
+                expires_at,
+            },
+        );
+
         Ok(ChannelEncryption {
-            algorithm: EncryptionAlgorithm::AesGcm256,
-            key: vec![0; 32],
-            iv: vec![0; 12],
-            signing_key: vec![0; 32],
+            algorithm: EncryptionAlgorithm::ChaCha20Poly1305,
+            key,
+            iv,
+            signing_key,
         })
     }
 
     async fn encrypt_message(&self, message: &BrokerMessage) -> Result<BrokerMessage, McpError> {
-        // TODO: 実装
-        Ok(message.clone())
+        if message.encrypted {
+            return Ok(message.clone());
+        }
+
+        let keys = self.key_manager.active_keys.read().await;
+        let key_material = keys.get(&message.source_plugin_id).ok_or_else(|| {
+            McpError::SecurityFailure(format!(
+                "No encryption key for source plugin {}",
+                message.source_plugin_id
+            ))
+        })?;
+
+        let mut nonce_bytes = [0u8; 12];
+        let nonce_input = digest::digest(
+            &digest::SHA256,
+            format!("{}:{}", message.message_id, message.timestamp.timestamp_nanos_opt().unwrap_or_default()).as_bytes(),
+        );
+        nonce_bytes.copy_from_slice(&nonce_input.as_ref()[..12]);
+
+        let cipher = ChaCha20Poly1305::new_from_slice(&key_material.primary_key)
+            .map_err(|e| McpError::SecurityFailure(format!("Invalid encryption key length: {e}")))?;
+
+        let ciphertext = cipher
+            .encrypt(&Nonce::from(nonce_bytes), message.payload.as_ref())
+            .map_err(|e| McpError::SecurityFailure(format!("Message encryption failed: {e}")))?;
+
+        let signature = hmac::sign(
+            &hmac::Key::new(hmac::HMAC_SHA256, &key_material.signing_key),
+            &ciphertext,
+        )
+        .as_ref()
+        .to_vec();
+
+        let mut encrypted = message.clone();
+        encrypted.payload = ciphertext;
+        encrypted.encrypted = true;
+        encrypted.signature = Some(signature);
+        encrypted
+            .metadata
+            .insert("nonce".to_string(), URL_SAFE_NO_PAD.encode(nonce_bytes));
+        encrypted.metadata.insert(
+            "algorithm".to_string(),
+            "chacha20poly1305+hmac-sha256".to_string(),
+        );
+
+        Ok(encrypted)
     }
 
     async fn decrypt_message(&self, message: &BrokerMessage) -> Result<BrokerMessage, McpError> {
-        // TODO: 実装
-        Ok(message.clone())
+        if !message.encrypted {
+            return Ok(message.clone());
+        }
+
+        let keys = self.key_manager.active_keys.read().await;
+        let key_material = keys.get(&message.source_plugin_id).ok_or_else(|| {
+            McpError::SecurityFailure(format!(
+                "No decryption key for source plugin {}",
+                message.source_plugin_id
+            ))
+        })?;
+
+        let signature = message.signature.as_ref().ok_or_else(|| {
+            McpError::SecurityFailure("Encrypted message missing signature".to_string())
+        })?;
+        hmac::verify(
+            &hmac::Key::new(hmac::HMAC_SHA256, &key_material.signing_key),
+            &message.payload,
+            signature,
+        )
+        .map_err(|_| McpError::SecurityFailure("Encrypted message signature verification failed".to_string()))?;
+
+        let nonce_b64 = message.metadata.get("nonce").ok_or_else(|| {
+            McpError::SecurityFailure("Encrypted message missing nonce metadata".to_string())
+        })?;
+        let nonce_raw = URL_SAFE_NO_PAD
+            .decode(nonce_b64)
+            .map_err(|e| McpError::SecurityFailure(format!("Invalid nonce encoding: {e}")))?;
+        if nonce_raw.len() != 12 {
+            return Err(McpError::SecurityFailure(
+                "Invalid nonce length for ChaCha20-Poly1305".to_string(),
+            ));
+        }
+
+        let cipher = ChaCha20Poly1305::new_from_slice(&key_material.primary_key)
+            .map_err(|e| McpError::SecurityFailure(format!("Invalid decryption key length: {e}")))?;
+        let nonce_array: [u8; 12] = nonce_raw
+            .as_slice()
+            .try_into()
+            .map_err(|_| McpError::SecurityFailure("Invalid nonce length for ChaCha20-Poly1305".to_string()))?;
+        let plaintext = cipher
+            .decrypt(&Nonce::from(nonce_array), message.payload.as_ref())
+            .map_err(|e| McpError::SecurityFailure(format!("Message decryption failed: {e}")))?;
+
+        let mut decrypted = message.clone();
+        decrypted.payload = plaintext;
+        decrypted.encrypted = false;
+        Ok(decrypted)
     }
 }
 
@@ -860,24 +1007,103 @@ impl AuthenticationManager {
         &self,
         plugin_id: Uuid,
     ) -> Result<AuthenticationInfo, McpError> {
-        // TODO: 実装
+        let now = chrono::Utc::now();
+        let expires_at = now + chrono::Duration::seconds(self.auth_config.token_lifetime_secs as i64);
+        let token = Self::generate_secure_token(plugin_id)?;
+
+        let (ecdh_public_key, signing_public_key) = Self::generate_plugin_key_material()?;
+        let key_id = format!("key_{}_{}", plugin_id, now.timestamp());
+
+        // Keep a lightweight certificate entry so peer verification metadata can be referenced.
+        {
+            let mut certs = self.certificate_store.certificates.write().await;
+            certs.insert(
+                key_id.clone(),
+                CertificateInfo {
+                    certificate: Vec::new(),
+                    public_key: signing_public_key.clone(),
+                    issuer: format!("plugin-auth-manager:{}", plugin_id),
+                    expires_at,
+                    revoked: false,
+                },
+            );
+        }
+
+        let token_info = TokenInfo {
+            token: token.clone(),
+            plugin_id,
+            issued_at: now,
+            expires_at,
+            permissions: vec![
+                "plugin:communicate".to_string(),
+                "plugin:e2e-encryption".to_string(),
+            ],
+            refreshable: self.auth_config.token_refresh_enabled,
+        };
+
+        {
+            let mut tokens = self.active_tokens.write().await;
+            tokens.insert(token.clone(), token_info);
+        }
+
         Ok(AuthenticationInfo {
-            token: format!("token_{}", plugin_id),
+            token,
             certificate: None,
-            public_key: vec![0; 32],
-            expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
-            permissions: vec!["read".to_string(), "write".to_string()],
+            public_key: ecdh_public_key,
+            signing_public_key,
+            key_id,
+            expires_at,
+            permissions: vec![
+                "plugin:communicate".to_string(),
+                "plugin:e2e-encryption".to_string(),
+            ],
         })
     }
 
-    async fn revoke_plugin_tokens(&self, _plugin_id: Uuid) -> Result<(), McpError> {
-        // TODO: 実装
+    async fn revoke_plugin_tokens(&self, plugin_id: Uuid) -> Result<(), McpError> {
+        let mut tokens = self.active_tokens.write().await;
+        tokens.retain(|_, info| info.plugin_id != plugin_id);
+
+        let mut certs = self.certificate_store.certificates.write().await;
+        let plugin_marker = plugin_id.to_string();
+        certs.retain(|_, cert| !cert.issuer.contains(&plugin_marker));
+
         Ok(())
     }
 
     async fn shutdown(&self) -> Result<(), McpError> {
-        // TODO: 実装
+        self.active_tokens.write().await.clear();
+        self.certificate_store.certificates.write().await.clear();
         Ok(())
+    }
+
+    fn generate_secure_token(plugin_id: Uuid) -> Result<String, McpError> {
+        let rng = SystemRandom::new();
+        let mut random = [0u8; 32];
+        rng.fill(&mut random)
+            .map_err(|e| McpError::SecurityFailure(format!("Failed to generate token entropy: {e}")))?;
+
+        let nonce = URL_SAFE_NO_PAD.encode(random);
+        Ok(format!("p_{}_{}", plugin_id.simple(), nonce))
+    }
+
+    fn generate_plugin_key_material() -> Result<(Vec<u8>, Vec<u8>), McpError> {
+        let rng = SystemRandom::new();
+
+        let mut ecdh_secret_bytes = [0u8; 32];
+        rng.fill(&mut ecdh_secret_bytes)
+            .map_err(|e| McpError::SecurityFailure(format!("Failed to generate ECDH key: {e}")))?;
+        let ecdh_secret = StaticSecret::from(ecdh_secret_bytes);
+        let ecdh_public = PublicKey::from(&ecdh_secret).to_bytes().to_vec();
+
+        let mut signing_secret_bytes = [0u8; 32];
+        rng.fill(&mut signing_secret_bytes).map_err(|e| {
+            McpError::SecurityFailure(format!("Failed to generate signing key material: {e}"))
+        })?;
+        let signing_key = SigningKey::from_bytes(&signing_secret_bytes);
+        let signing_public = signing_key.verifying_key().to_bytes().to_vec();
+
+        Ok((ecdh_public, signing_public))
     }
 }
 
@@ -932,5 +1158,179 @@ mod tests {
 
         let limiter = RateLimiter::new(config);
         assert!(limiter.config.enabled);
+    }
+
+    /// E2E暗号化ラウンドトリップテスト:
+    /// ChaCha20-Poly1305 で暗号化したメッセージを復号し、
+    /// ペイロードが元のデータと一致することを確認する。
+    #[tokio::test]
+    async fn test_e2e_encryption_roundtrip() {
+        let config = EncryptionConfig {
+            default_algorithm: EncryptionAlgorithm::ChaCha20Poly1305,
+            key_rotation: KeyRotationConfig {
+                rotation_interval_hours: 24,
+                auto_rotation_enabled: false,
+                overlap_hours: 0,
+            },
+            encryption_required: true,
+        };
+        let manager = EncryptionManager::new(&config).await.unwrap();
+        let plugin_id = Uuid::new_v4();
+
+        // チャネル鍵を生成 (KeyManager に登録される)
+        manager
+            .generate_channel_encryption(plugin_id)
+            .await
+            .unwrap();
+
+        let original_payload = b"Hello, secure world!".to_vec();
+        let message = BrokerMessage {
+            message_id: Uuid::new_v4(),
+            source_plugin_id: plugin_id,
+            destination_plugin_id: None,
+            message_type: MessageType::Request,
+            payload: original_payload.clone(),
+            encrypted: false,
+            signature: None,
+            timestamp: chrono::Utc::now(),
+            expires_at: None,
+            metadata: HashMap::new(),
+        };
+
+        // 暗号化
+        let encrypted = manager.encrypt_message(&message).await.unwrap();
+        assert!(encrypted.encrypted, "メッセージは暗号化されているべき");
+        assert_ne!(
+            encrypted.payload, original_payload,
+            "暗号文は平文と異なるべき"
+        );
+        assert!(encrypted.signature.is_some(), "HMAC署名が付与されているべき");
+        assert!(
+            encrypted.metadata.contains_key("nonce"),
+            "nonceメタデータが存在するべき"
+        );
+        assert_eq!(
+            encrypted.metadata.get("algorithm").map(String::as_str),
+            Some("chacha20poly1305+hmac-sha256"),
+            "アルゴリズムメタデータが正しく設定されているべき"
+        );
+
+        // 復号
+        let decrypted = manager.decrypt_message(&encrypted).await.unwrap();
+        assert!(!decrypted.encrypted, "復号後は encrypted=false になるべき");
+        assert_eq!(
+            decrypted.payload, original_payload,
+            "復号したペイロードが元のデータと一致するべき"
+        );
+    }
+
+    /// 改ざん検出テスト:
+    /// 暗号文のバイトを反転させた場合、HMAC署名検証が失敗し
+    /// `decrypt_message` がエラーを返すことを確認する。
+    #[tokio::test]
+    async fn test_tampered_ciphertext_detection() {
+        let config = EncryptionConfig {
+            default_algorithm: EncryptionAlgorithm::ChaCha20Poly1305,
+            key_rotation: KeyRotationConfig {
+                rotation_interval_hours: 24,
+                auto_rotation_enabled: false,
+                overlap_hours: 0,
+            },
+            encryption_required: true,
+        };
+        let manager = EncryptionManager::new(&config).await.unwrap();
+        let plugin_id = Uuid::new_v4();
+
+        manager
+            .generate_channel_encryption(plugin_id)
+            .await
+            .unwrap();
+
+        let message = BrokerMessage {
+            message_id: Uuid::new_v4(),
+            source_plugin_id: plugin_id,
+            destination_plugin_id: None,
+            message_type: MessageType::Request,
+            payload: b"sensitive data".to_vec(),
+            encrypted: false,
+            signature: None,
+            timestamp: chrono::Utc::now(),
+            expires_at: None,
+            metadata: HashMap::new(),
+        };
+
+        let mut encrypted = manager.encrypt_message(&message).await.unwrap();
+
+        // 暗号文の先頭バイトを反転して改ざんを模倣
+        if let Some(byte) = encrypted.payload.first_mut() {
+            *byte ^= 0xFF;
+        }
+
+        // HMAC 署名検証が失敗し復号エラーになるはず
+        let result = manager.decrypt_message(&encrypted).await;
+        assert!(result.is_err(), "改ざんされた暗号文は復号に失敗するべき");
+        let err_str = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_str.contains("signature verification failed")
+                || err_str.contains("SecurityFailure"),
+            "エラーは署名検証失敗を示すべき: {err_str}"
+        );
+    }
+
+    /// nonceユニーク性テスト (リプレイ攻撃対策):
+    /// 同じプラグインから送られた異なる2つのメッセージは、
+    /// それぞれ一意のnonceを持つことを確認する。
+    /// (ChaCha20-Poly1305 は同一鍵+同一nonceの再利用が禁止されているため)
+    #[tokio::test]
+    async fn test_nonce_uniqueness_prevents_replay() {
+        let config = EncryptionConfig {
+            default_algorithm: EncryptionAlgorithm::ChaCha20Poly1305,
+            key_rotation: KeyRotationConfig {
+                rotation_interval_hours: 24,
+                auto_rotation_enabled: false,
+                overlap_hours: 0,
+            },
+            encryption_required: true,
+        };
+        let manager = EncryptionManager::new(&config).await.unwrap();
+        let plugin_id = Uuid::new_v4();
+
+        manager
+            .generate_channel_encryption(plugin_id)
+            .await
+            .unwrap();
+
+        let make_message = |payload: &'static [u8]| BrokerMessage {
+            message_id: Uuid::new_v4(),
+            source_plugin_id: plugin_id,
+            destination_plugin_id: None,
+            message_type: MessageType::Request,
+            payload: payload.to_vec(),
+            encrypted: false,
+            signature: None,
+            timestamp: chrono::Utc::now(),
+            expires_at: None,
+            metadata: HashMap::new(),
+        };
+
+        let msg1 = make_message(b"message one");
+        let msg2 = make_message(b"message two");
+
+        let enc1 = manager.encrypt_message(&msg1).await.unwrap();
+        let enc2 = manager.encrypt_message(&msg2).await.unwrap();
+
+        let nonce1 = enc1.metadata.get("nonce").expect("nonce1 が存在するべき");
+        let nonce2 = enc2.metadata.get("nonce").expect("nonce2 が存在するべき");
+
+        assert_ne!(
+            nonce1, nonce2,
+            "異なるメッセージIDから生成されたnonceは一意であるべき（リプレイ攻撃対策）"
+        );
+
+        // 両メッセージを正常に復号できることも確認
+        let dec1 = manager.decrypt_message(&enc1).await.unwrap();
+        let dec2 = manager.decrypt_message(&enc2).await.unwrap();
+        assert_eq!(dec1.payload, b"message one");
+        assert_eq!(dec2.payload, b"message two");
     }
 }

--- a/src/plugin_isolation/communication_broker.rs
+++ b/src/plugin_isolation/communication_broker.rs
@@ -550,7 +550,10 @@ impl CommunicationBroker {
         let auth_manager = Arc::new(AuthenticationManager::new(config.auth_config.clone()).await?);
         let message_queue = Arc::new(MessageQueue::new(config.queue_config.clone()).await?);
         let kex_config = KeyExchangeConfig {
-            key_lifetime_hours: config.encryption_config.key_rotation.rotation_interval_hours,
+            key_lifetime_hours: config
+                .encryption_config
+                .key_rotation
+                .rotation_interval_hours,
             grace_period_hours: config.encryption_config.key_rotation.overlap_hours,
             message_ttl_secs: 300,
         };
@@ -672,7 +675,9 @@ impl CommunicationBroker {
         self.auth_manager.revoke_plugin_tokens(plugin_id).await?;
 
         // E2E 鍵交換プロトコルからプラグインを削除
-        self.key_exchange_protocol.unregister_plugin(plugin_id).await;
+        self.key_exchange_protocol
+            .unregister_plugin(plugin_id)
+            .await;
 
         info!("Communication channel unregistered: {}", plugin_id);
         Ok(())
@@ -861,16 +866,21 @@ impl EncryptionManager {
         let mut iv = vec![0u8; 12];
         let mut signing_key = vec![0u8; 32];
 
-        rng.fill(&mut key)
-            .map_err(|e| McpError::SecurityFailure(format!("Failed to generate channel key: {e}")))?;
-        rng.fill(&mut iv)
-            .map_err(|e| McpError::SecurityFailure(format!("Failed to generate channel nonce: {e}")))?;
-        rng.fill(&mut signing_key)
-            .map_err(|e| McpError::SecurityFailure(format!("Failed to generate signing key: {e}")))?;
+        rng.fill(&mut key).map_err(|e| {
+            McpError::SecurityFailure(format!("Failed to generate channel key: {e}"))
+        })?;
+        rng.fill(&mut iv).map_err(|e| {
+            McpError::SecurityFailure(format!("Failed to generate channel nonce: {e}"))
+        })?;
+        rng.fill(&mut signing_key).map_err(|e| {
+            McpError::SecurityFailure(format!("Failed to generate signing key: {e}"))
+        })?;
 
         let now = chrono::Utc::now();
         let expires_at = now
-            + chrono::Duration::hours(self.key_manager.rotation_config.rotation_interval_hours as i64);
+            + chrono::Duration::hours(
+                self.key_manager.rotation_config.rotation_interval_hours as i64,
+            );
         let mut active_keys = self.key_manager.active_keys.write().await;
         active_keys.insert(
             plugin_id,
@@ -907,12 +917,18 @@ impl EncryptionManager {
         let mut nonce_bytes = [0u8; 12];
         let nonce_input = digest::digest(
             &digest::SHA256,
-            format!("{}:{}", message.message_id, message.timestamp.timestamp_nanos_opt().unwrap_or_default()).as_bytes(),
+            format!(
+                "{}:{}",
+                message.message_id,
+                message.timestamp.timestamp_nanos_opt().unwrap_or_default()
+            )
+            .as_bytes(),
         );
         nonce_bytes.copy_from_slice(&nonce_input.as_ref()[..12]);
 
-        let cipher = ChaCha20Poly1305::new_from_slice(&key_material.primary_key)
-            .map_err(|e| McpError::SecurityFailure(format!("Invalid encryption key length: {e}")))?;
+        let cipher = ChaCha20Poly1305::new_from_slice(&key_material.primary_key).map_err(|e| {
+            McpError::SecurityFailure(format!("Invalid encryption key length: {e}"))
+        })?;
 
         let ciphertext = cipher
             .encrypt(&Nonce::from(nonce_bytes), message.payload.as_ref())
@@ -961,7 +977,9 @@ impl EncryptionManager {
             &message.payload,
             signature,
         )
-        .map_err(|_| McpError::SecurityFailure("Encrypted message signature verification failed".to_string()))?;
+        .map_err(|_| {
+            McpError::SecurityFailure("Encrypted message signature verification failed".to_string())
+        })?;
 
         let nonce_b64 = message.metadata.get("nonce").ok_or_else(|| {
             McpError::SecurityFailure("Encrypted message missing nonce metadata".to_string())
@@ -975,12 +993,12 @@ impl EncryptionManager {
             ));
         }
 
-        let cipher = ChaCha20Poly1305::new_from_slice(&key_material.primary_key)
-            .map_err(|e| McpError::SecurityFailure(format!("Invalid decryption key length: {e}")))?;
-        let nonce_array: [u8; 12] = nonce_raw
-            .as_slice()
-            .try_into()
-            .map_err(|_| McpError::SecurityFailure("Invalid nonce length for ChaCha20-Poly1305".to_string()))?;
+        let cipher = ChaCha20Poly1305::new_from_slice(&key_material.primary_key).map_err(|e| {
+            McpError::SecurityFailure(format!("Invalid decryption key length: {e}"))
+        })?;
+        let nonce_array: [u8; 12] = nonce_raw.as_slice().try_into().map_err(|_| {
+            McpError::SecurityFailure("Invalid nonce length for ChaCha20-Poly1305".to_string())
+        })?;
         let plaintext = cipher
             .decrypt(&Nonce::from(nonce_array), message.payload.as_ref())
             .map_err(|e| McpError::SecurityFailure(format!("Message decryption failed: {e}")))?;
@@ -1008,7 +1026,8 @@ impl AuthenticationManager {
         plugin_id: Uuid,
     ) -> Result<AuthenticationInfo, McpError> {
         let now = chrono::Utc::now();
-        let expires_at = now + chrono::Duration::seconds(self.auth_config.token_lifetime_secs as i64);
+        let expires_at =
+            now + chrono::Duration::seconds(self.auth_config.token_lifetime_secs as i64);
         let token = Self::generate_secure_token(plugin_id)?;
 
         let (ecdh_public_key, signing_public_key) = Self::generate_plugin_key_material()?;
@@ -1080,8 +1099,9 @@ impl AuthenticationManager {
     fn generate_secure_token(plugin_id: Uuid) -> Result<String, McpError> {
         let rng = SystemRandom::new();
         let mut random = [0u8; 32];
-        rng.fill(&mut random)
-            .map_err(|e| McpError::SecurityFailure(format!("Failed to generate token entropy: {e}")))?;
+        rng.fill(&mut random).map_err(|e| {
+            McpError::SecurityFailure(format!("Failed to generate token entropy: {e}"))
+        })?;
 
         let nonce = URL_SAFE_NO_PAD.encode(random);
         Ok(format!("p_{}_{}", plugin_id.simple(), nonce))
@@ -1204,7 +1224,10 @@ mod tests {
             encrypted.payload, original_payload,
             "暗号文は平文と異なるべき"
         );
-        assert!(encrypted.signature.is_some(), "HMAC署名が付与されているべき");
+        assert!(
+            encrypted.signature.is_some(),
+            "HMAC署名が付与されているべき"
+        );
         assert!(
             encrypted.metadata.contains_key("nonce"),
             "nonceメタデータが存在するべき"

--- a/src/plugin_isolation/key_exchange.rs
+++ b/src/plugin_isolation/key_exchange.rs
@@ -1,0 +1,982 @@
+//! プラグイン間鍵交換プロトコルと E2E 暗号化専用型
+//!
+//! X25519 ECDH による一時鍵交換、HKDF-SHA256 による鍵導出、
+//! ChaCha20-Poly1305 による認証付き暗号化、Ed25519 による署名を組み合わせ
+//! Perfect Forward Secrecy (PFS) 対応のエンドツーエンド暗号化を提供します。
+//!
+//! ## 設計
+//!
+//! ```text
+//! Plugin A ─── initiate_key_exchange() ──> Plugin B
+//!              ECDH: a_secret * b_public = b_secret * a_public
+//!              HKDF-SHA256 → symmetric key K
+//!              ChaCha20-Poly1305(K) + Ed25519 sign
+//!              expires_at = now + message_ttl_secs  (リプレイ攻撃対策)
+//! ```
+//!
+//! ## グレースピリオドによるローリングローテーション
+//!
+//! `rotate_session` を呼ぶと旧鍵が `secondary_key` として `grace_period_hours` 保持され、
+//! ローテーション前に暗号化されたメッセージも引き続き復号できます。
+//!
+//! ## 使用例
+//!
+//! ```rust,ignore
+//! let config = KeyExchangeConfig::default();
+//! let protocol = Arc::new(KeyExchangeProtocol::new_with_config(config));
+//! protocol.register_plugin(plugin_a).await?;
+//! protocol.register_plugin(plugin_b).await?;
+//! protocol.initiate_key_exchange(plugin_a, plugin_b).await?;
+//! KeyExchangeProtocol::start_auto_rotation(Arc::clone(&protocol));
+//!
+//! let payload = protocol.encrypt_for_peer(plugin_a, plugin_b, b"hello").await?;
+//! let plain   = protocol.decrypt_from_peer(plugin_b, plugin_a, &payload).await?;
+//! ```
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit, Nonce};
+use chrono::{DateTime, Utc};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ring::{
+    hkdf,
+    rand::{SecureRandom, SystemRandom},
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+use tracing::warn;
+use uuid::Uuid;
+use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret};
+
+use crate::error::Error as McpError;
+
+// ---------------------------------------------------------------------------
+// HKDF KeyType 実装
+// ---------------------------------------------------------------------------
+
+/// HKDF-SHA256 で 32 バイト鍵を導出するための `ring::hkdf::KeyType` 実装
+struct HkdfKey32;
+
+impl hkdf::KeyType for HkdfKey32 {
+    fn len(&self) -> usize {
+        32
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KeyExchangeConfig
+// ---------------------------------------------------------------------------
+
+/// 鍵交換プロトコル設定
+#[derive(Debug, Clone)]
+pub struct KeyExchangeConfig {
+    /// セッション鍵の有効期間（時間）
+    pub key_lifetime_hours: u64,
+    /// 鍵ローテーション後の旧鍵グレースピリオド（時間）
+    ///
+    /// ローテーション直後は新旧両方の鍵で復号を試みます。
+    /// ローリングデプロイや遅延メッセージに対する後方互換性を確保します。
+    pub grace_period_hours: u64,
+    /// 暗号化メッセージの有効期間（秒）
+    ///
+    /// `expires_at` を超えたペイロードは復号を拒否します（リプレイ攻撃対策）。
+    pub message_ttl_secs: u64,
+}
+
+impl Default for KeyExchangeConfig {
+    fn default() -> Self {
+        Self {
+            key_lifetime_hours: 24,
+            grace_period_hours: 1,
+            message_ttl_secs: 300, // 5 分
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 公開型: EncryptedPayload
+// ---------------------------------------------------------------------------
+
+/// E2E 暗号化ペイロード
+///
+/// ChaCha20-Poly1305 で暗号化し Ed25519 で署名した独立型。
+/// `BrokerMessage.payload` の代替としてプラグイン間通信で使用できます。
+///
+/// `timestamp` / `expires_at` はリプレイ攻撃対策です。
+/// 受信側は `Utc::now().timestamp() > expires_at` であれば復号を拒否します。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncryptedPayload {
+    /// ChaCha20-Poly1305 暗号文（認証タグを含む）
+    pub ciphertext: Vec<u8>,
+    /// 12 バイト nonce (ランダム生成)
+    pub nonce: [u8; 12],
+    /// 送信者側 X25519 ECDH 公開鍵（32 バイト）
+    pub sender_ecdh_public_key: [u8; 32],
+    /// 暗号文に対する Ed25519 署名（64 バイト）
+    pub signature: Vec<u8>,
+    /// 暗号化時刻（Unix 秒）
+    pub timestamp: i64,
+    /// メッセージ有効期限（Unix 秒）
+    ///
+    /// `Utc::now().timestamp() > expires_at` の場合、`decrypt` はエラーを返します。
+    pub expires_at: i64,
+}
+
+// ---------------------------------------------------------------------------
+// 内部型: SessionKey
+// ---------------------------------------------------------------------------
+
+/// プラグインペア間 HKDF 導出済み対称鍵
+#[derive(Debug, Clone)]
+struct SessionKey {
+    /// プライマリ鍵（最新のローテーション後の鍵）
+    key: [u8; 32],
+    /// セカンダリ鍵（直前のローテーション前の旧鍵 — グレースピリオド中のみ有効）
+    secondary_key: Option<[u8; 32]>,
+    /// セカンダリ鍵の有効期限
+    secondary_expires_at: Option<DateTime<Utc>>,
+    /// 自身の X25519 公開鍵（EncryptedPayload に埋め込むため保持）
+    my_ecdh_public: [u8; 32],
+    /// ピアの Ed25519 検証公開鍵（署名検証用）
+    peer_verifying_key: [u8; 32],
+    /// 鍵生成日時
+    created_at: DateTime<Utc>,
+    /// プライマリ鍵有効期限
+    expires_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// PluginCryptoContext
+// ---------------------------------------------------------------------------
+
+/// プラグイン暗号コンテキスト
+///
+/// 1 プラグインにつき 1 インスタンス。
+/// Ed25519 署名鍵ペアを保持し、ピアごとの HKDF 共有鍵をキャッシュします。
+#[derive(Debug)]
+pub struct PluginCryptoContext {
+    /// このコンテキストを所有するプラグインの UUID
+    pub plugin_id: Uuid,
+    /// Ed25519 署名鍵（秘密鍵 + 公開鍵）
+    signing_key: SigningKey,
+    /// peer_plugin_id → セッション鍵 のキャッシュ
+    session_keys: HashMap<Uuid, SessionKey>,
+}
+
+impl PluginCryptoContext {
+    /// 新しい暗号コンテキストを生成する
+    pub fn new(plugin_id: Uuid) -> Result<Self, McpError> {
+        let rng = SystemRandom::new();
+        let mut sk_bytes = [0u8; 32];
+        rng.fill(&mut sk_bytes).map_err(|e| {
+            McpError::SecurityFailure(format!(
+                "PluginCryptoContext: failed to generate Ed25519 signing key: {e}"
+            ))
+        })?;
+        Ok(Self {
+            plugin_id,
+            signing_key: SigningKey::from_bytes(&sk_bytes),
+            session_keys: HashMap::new(),
+        })
+    }
+
+    /// Ed25519 検証公開鍵（32 バイト）を返す
+    pub fn verifying_key_bytes(&self) -> [u8; 32] {
+        self.signing_key.verifying_key().to_bytes()
+    }
+
+    /// ペイロードを ChaCha20-Poly1305 で暗号化し Ed25519 で署名して返す
+    ///
+    /// `message_ttl_secs`: メッセージ有効期間（秒）。超過すると受信側で拒否されます。
+    pub fn encrypt(
+        &self,
+        peer_id: Uuid,
+        plaintext: &[u8],
+        message_ttl_secs: u64,
+    ) -> Result<EncryptedPayload, McpError> {
+        let session = self.get_valid_session(peer_id)?;
+
+        // 暗号化ごとに一意な nonce をランダム生成（nonce 再利用防止）
+        let rng = SystemRandom::new();
+        let mut nonce_bytes = [0u8; 12];
+        rng.fill(&mut nonce_bytes)
+            .map_err(|e| McpError::SecurityFailure(format!("Nonce generation failed: {e}")))?;
+
+        let cipher = ChaCha20Poly1305::new_from_slice(&session.key)
+            .map_err(|e| McpError::SecurityFailure(format!("Cipher init failed: {e}")))?;
+        let ciphertext = cipher
+            .encrypt(&Nonce::from(nonce_bytes), plaintext)
+            .map_err(|e| McpError::SecurityFailure(format!("Encryption failed: {e}")))?;
+
+        // 暗号文に Ed25519 署名を付与（改ざん検出）
+        let sig: Signature = self.signing_key.sign(&ciphertext);
+
+        let now = Utc::now().timestamp();
+        Ok(EncryptedPayload {
+            ciphertext,
+            nonce: nonce_bytes,
+            sender_ecdh_public_key: session.my_ecdh_public,
+            signature: sig.to_bytes().to_vec(),
+            timestamp: now,
+            expires_at: now + message_ttl_secs as i64,
+        })
+    }
+
+    /// 署名検証 → 期限チェック → 復号（グレースピリオド対応）
+    ///
+    /// 処理順序:
+    /// 1. Ed25519 署名検証（改ざん検知 — 復号前に必ず実施）
+    /// 2. `expires_at` 期限チェック（リプレイ攻撃対策）
+    /// 3. プライマリ鍵で ChaCha20-Poly1305 復号
+    /// 4. 失敗時: グレースピリオド内であればセカンダリ鍵（旧鍵）で再試行
+    pub fn decrypt(
+        &self,
+        peer_id: Uuid,
+        payload: &EncryptedPayload,
+    ) -> Result<Vec<u8>, McpError> {
+        let session = self.get_valid_session(peer_id)?;
+
+        // 1. Ed25519 署名検証（改ざん検知 — 復号前に必ず実施）
+        let verifying_key = VerifyingKey::from_bytes(&session.peer_verifying_key)
+            .map_err(|e| McpError::SecurityFailure(format!("Invalid peer verifying key: {e}")))?;
+        let sig_bytes: [u8; 64] = payload
+            .signature
+            .as_slice()
+            .try_into()
+            .map_err(|_| McpError::SecurityFailure("Invalid Ed25519 signature length".to_string()))?;
+        let sig = Signature::from_bytes(&sig_bytes);
+        verifying_key.verify(&payload.ciphertext, &sig).map_err(|_| {
+            McpError::SecurityFailure("Ed25519 signature verification failed".to_string())
+        })?;
+
+        // 2. タイムスタンプ期限チェック（リプレイ攻撃対策）
+        let now_ts = Utc::now().timestamp();
+        if now_ts > payload.expires_at {
+            return Err(McpError::SecurityFailure(format!(
+                "Message expired (expires_at={}, now={}); possible replay attack",
+                payload.expires_at, now_ts
+            )));
+        }
+
+        // 3. プライマリ鍵で復号
+        let cipher = ChaCha20Poly1305::new_from_slice(&session.key)
+            .map_err(|e| McpError::SecurityFailure(format!("Cipher init failed: {e}")))?;
+        if let Ok(plaintext) =
+            cipher.decrypt(&Nonce::from(payload.nonce), payload.ciphertext.as_ref())
+        {
+            return Ok(plaintext);
+        }
+
+        // 4. プライマリ鍵で失敗 → セカンダリ鍵（グレースピリオド）でフォールバック
+        //    鍵ローテーション直後に旧鍵で暗号化されたメッセージを復号するために使用
+        if let (Some(secondary_key), Some(secondary_expires)) =
+            (session.secondary_key, session.secondary_expires_at)
+        {
+            if Utc::now() <= secondary_expires {
+                let cipher2 = ChaCha20Poly1305::new_from_slice(&secondary_key)
+                    .map_err(|e| McpError::SecurityFailure(format!("Cipher init failed: {e}")))?;
+                return cipher2
+                    .decrypt(&Nonce::from(payload.nonce), payload.ciphertext.as_ref())
+                    .map_err(|_| {
+                        McpError::SecurityFailure(
+                            "Decryption failed with both primary and secondary (grace period) keys"
+                                .to_string(),
+                        )
+                    });
+            }
+        }
+
+        Err(McpError::SecurityFailure(
+            "Decryption failed: no valid key available".to_string(),
+        ))
+    }
+
+    /// 指定ピアとのセッション鍵を失効させる
+    pub fn invalidate_session(&mut self, peer_id: Uuid) {
+        self.session_keys.remove(&peer_id);
+    }
+
+    /// セッション鍵が存在かつ有効期限内であることを検証して返す
+    fn get_valid_session(&self, peer_id: Uuid) -> Result<&SessionKey, McpError> {
+        let session = self.session_keys.get(&peer_id).ok_or_else(|| {
+            McpError::SecurityFailure(format!(
+                "No session key established for peer plugin {peer_id}"
+            ))
+        })?;
+        if Utc::now() > session.expires_at {
+            return Err(McpError::SecurityFailure(format!(
+                "Session key for peer {peer_id} has expired; call rotate_session() to refresh"
+            )));
+        }
+        Ok(session)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KeyExchangeProtocol
+// ---------------------------------------------------------------------------
+
+/// 鍵交換プロトコル
+///
+/// プラグインを登録し、X25519 ECDH + HKDF-SHA256 を用いて
+/// プラグインペア間の共有鍵を確立するオーケストレーター。
+///
+/// ## Perfect Forward Secrecy
+///
+/// `initiate_key_exchange` を呼ぶたびに新しい X25519 エフェメラル鍵ペアを生成するため、
+/// セッション鍵が漏洩しても過去の通信は解読できません。
+///
+/// ## 自動キーローテーション
+///
+/// `start_auto_rotation(Arc::clone(&protocol))` でバックグラウンドタスクを開始し
+/// `config.key_lifetime_hours` の間隔で全確立済みペアの鍵を自動更新します。
+#[derive(Debug)]
+pub struct KeyExchangeProtocol {
+    /// plugin_id → PluginCryptoContext
+    contexts: Arc<RwLock<HashMap<Uuid, PluginCryptoContext>>>,
+    /// 確立済みセッションペアのセット（正規化ペア: min_id < max_id）
+    ///
+    /// 自動ローテーションタスクが参照します。
+    session_pairs: Arc<RwLock<HashSet<(Uuid, Uuid)>>>,
+    /// 設定
+    config: KeyExchangeConfig,
+}
+
+impl KeyExchangeProtocol {
+    /// デフォルト設定でインスタンスを作成する（`key_lifetime_hours` のみ指定）
+    ///
+    /// `grace_period_hours = 1`, `message_ttl_secs = 300` が設定されます。
+    pub fn new(key_lifetime_hours: u64) -> Self {
+        Self::new_with_config(KeyExchangeConfig {
+            key_lifetime_hours,
+            ..Default::default()
+        })
+    }
+
+    /// フル設定でインスタンスを作成する
+    pub fn new_with_config(config: KeyExchangeConfig) -> Self {
+        Self {
+            contexts: Arc::new(RwLock::new(HashMap::new())),
+            session_pairs: Arc::new(RwLock::new(HashSet::new())),
+            config,
+        }
+    }
+
+    /// プラグインを登録して Ed25519 検証公開鍵を返す
+    pub async fn register_plugin(&self, plugin_id: Uuid) -> Result<[u8; 32], McpError> {
+        let ctx = PluginCryptoContext::new(plugin_id)?;
+        let verifying_key = ctx.verifying_key_bytes();
+        self.contexts.write().await.insert(plugin_id, ctx);
+        Ok(verifying_key)
+    }
+
+    /// プラグインの登録を解除してコンテキストと関連セッションペアを削除する
+    pub async fn unregister_plugin(&self, plugin_id: Uuid) {
+        self.contexts.write().await.remove(&plugin_id);
+        // 当プラグインを含む全ペアを削除
+        self.session_pairs
+            .write()
+            .await
+            .retain(|(a, b)| *a != plugin_id && *b != plugin_id);
+    }
+
+    /// X25519 ECDH 鍵交換を実行してセッション鍵を確立（または更新）する
+    ///
+    /// 既存セッションがある場合、旧鍵を `secondary_key` として
+    /// `config.grace_period_hours` の間保持します（グレースピリオド）。
+    ///
+    /// ## DH 数学的保証
+    ///
+    /// ```text
+    /// shared = a_secret · b_public = b_secret · a_public  (X25519)
+    /// HKDF-SHA256(shared, "plugin-e2e-encryption-v1") → 32-byte symmetric key
+    /// ```
+    pub async fn initiate_key_exchange(
+        &self,
+        plugin_a: Uuid,
+        plugin_b: Uuid,
+    ) -> Result<(), McpError> {
+        let mut contexts = self.contexts.write().await;
+
+        if !contexts.contains_key(&plugin_a) {
+            return Err(McpError::SecurityFailure(format!(
+                "Plugin {plugin_a} is not registered in KeyExchangeProtocol"
+            )));
+        }
+        if !contexts.contains_key(&plugin_b) {
+            return Err(McpError::SecurityFailure(format!(
+                "Plugin {plugin_b} is not registered in KeyExchangeProtocol"
+            )));
+        }
+
+        // 双方の Ed25519 検証公開鍵を取得
+        let verifying_a = contexts[&plugin_a].verifying_key_bytes();
+        let verifying_b = contexts[&plugin_b].verifying_key_bytes();
+
+        // 既存セッション鍵を保存（ローテーション時のグレースピリオド用）
+        let old_key_a = contexts[&plugin_a]
+            .session_keys
+            .get(&plugin_b)
+            .map(|s| s.key);
+        let old_key_b = contexts[&plugin_b]
+            .session_keys
+            .get(&plugin_a)
+            .map(|s| s.key);
+
+        // X25519 エフェメラル鍵ペア生成（PFS: 毎回新しいランダム鍵）
+        let rng = SystemRandom::new();
+        let mut bytes_a = [0u8; 32];
+        let mut bytes_b = [0u8; 32];
+        rng.fill(&mut bytes_a).map_err(|e| {
+            McpError::SecurityFailure(format!("ECDH key generation failed for plugin_a: {e}"))
+        })?;
+        rng.fill(&mut bytes_b).map_err(|e| {
+            McpError::SecurityFailure(format!("ECDH key generation failed for plugin_b: {e}"))
+        })?;
+
+        let secret_a = StaticSecret::from(bytes_a);
+        let secret_b = StaticSecret::from(bytes_b);
+        let public_a = X25519PublicKey::from(&secret_a);
+        let public_b = X25519PublicKey::from(&secret_b);
+
+        // DH: secret_a · public_b = secret_b · public_a  (同一の共有秘密)
+        let shared_secret = secret_a.diffie_hellman(&public_b);
+
+        // HKDF-SHA256 で 32 バイト対称鍵を導出
+        let salt = hkdf::Salt::new(hkdf::HKDF_SHA256, &[]);
+        let prk = salt.extract(shared_secret.as_bytes());
+        let mut derived_key = [0u8; 32];
+        prk.expand(&[b"plugin-e2e-encryption-v1"], HkdfKey32)
+            .map_err(|_| McpError::SecurityFailure("HKDF expand failed".to_string()))?
+            .fill(&mut derived_key)
+            .map_err(|_| McpError::SecurityFailure("HKDF fill failed".to_string()))?;
+
+        let now = Utc::now();
+        let session_expires_at =
+            now + chrono::Duration::hours(self.config.key_lifetime_hours as i64);
+        let secondary_expires_at =
+            now + chrono::Duration::hours(self.config.grace_period_hours as i64);
+
+        // plugin_a のコンテキストに共有鍵を設定（旧鍵 → secondary_key）
+        contexts.get_mut(&plugin_a).unwrap().session_keys.insert(
+            plugin_b,
+            SessionKey {
+                key: derived_key,
+                secondary_key: old_key_a,
+                secondary_expires_at: old_key_a.map(|_| secondary_expires_at),
+                my_ecdh_public: public_a.to_bytes(),
+                peer_verifying_key: verifying_b,
+                created_at: now,
+                expires_at: session_expires_at,
+            },
+        );
+
+        // plugin_b のコンテキストに共有鍵を設定（同一の derived_key を共有）
+        contexts.get_mut(&plugin_b).unwrap().session_keys.insert(
+            plugin_a,
+            SessionKey {
+                key: derived_key,
+                secondary_key: old_key_b,
+                secondary_expires_at: old_key_b.map(|_| secondary_expires_at),
+                my_ecdh_public: public_b.to_bytes(),
+                peer_verifying_key: verifying_a,
+                created_at: now,
+                expires_at: session_expires_at,
+            },
+        );
+
+        // ペアを確立済みセットに記録（正規化して重複防止）
+        drop(contexts);
+        self.session_pairs
+            .write()
+            .await
+            .insert(Self::canonical_pair(plugin_a, plugin_b));
+
+        Ok(())
+    }
+
+    /// `sender` として `recipient` 宛にメッセージを暗号化する
+    ///
+    /// メッセージ有効期限は `config.message_ttl_secs` で自動設定されます。
+    pub async fn encrypt_for_peer(
+        &self,
+        sender: Uuid,
+        recipient: Uuid,
+        plaintext: &[u8],
+    ) -> Result<EncryptedPayload, McpError> {
+        let contexts = self.contexts.read().await;
+        let ctx = contexts.get(&sender).ok_or_else(|| {
+            McpError::SecurityFailure(format!(
+                "Sender plugin {sender} is not registered in KeyExchangeProtocol"
+            ))
+        })?;
+        ctx.encrypt(recipient, plaintext, self.config.message_ttl_secs)
+    }
+
+    /// `sender` から `recipient` 宛の [`EncryptedPayload`] を検証・復号する
+    pub async fn decrypt_from_peer(
+        &self,
+        recipient: Uuid,
+        sender: Uuid,
+        payload: &EncryptedPayload,
+    ) -> Result<Vec<u8>, McpError> {
+        let contexts = self.contexts.read().await;
+        let ctx = contexts.get(&recipient).ok_or_else(|| {
+            McpError::SecurityFailure(format!(
+                "Recipient plugin {recipient} is not registered in KeyExchangeProtocol"
+            ))
+        })?;
+        ctx.decrypt(sender, payload)
+    }
+
+    /// セッション鍵を再生成する（手動鍵ローテーション）
+    ///
+    /// 旧鍵は `grace_period_hours` の間 `secondary_key` として保持されます。
+    pub async fn rotate_session(&self, plugin_a: Uuid, plugin_b: Uuid) -> Result<(), McpError> {
+        self.initiate_key_exchange(plugin_a, plugin_b).await
+    }
+
+    /// 自動キーローテーション バックグラウンドタスクを開始する
+    ///
+    /// `config.key_lifetime_hours` の間隔で全確立済みペアの `rotate_session` を呼び出します。
+    /// 返値の `JoinHandle` を `abort()` することでタスクを停止できます。
+    ///
+    /// ## 使用例
+    ///
+    /// ```rust,ignore
+    /// let handle = KeyExchangeProtocol::start_auto_rotation(Arc::clone(&protocol));
+    /// // ... 停止する場合:
+    /// handle.abort();
+    /// ```
+    pub fn start_auto_rotation(protocol: Arc<Self>) -> tokio::task::JoinHandle<()> {
+        let interval_secs = protocol.config.key_lifetime_hours * 3600;
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_secs(interval_secs)).await;
+
+                let pairs: Vec<(Uuid, Uuid)> = protocol
+                    .session_pairs
+                    .read()
+                    .await
+                    .iter()
+                    .cloned()
+                    .collect();
+
+                for (a, b) in pairs {
+                    if let Err(e) = protocol.rotate_session(a, b).await {
+                        warn!(
+                            "Auto key rotation failed for pair ({}, {}): {}",
+                            a, b, e
+                        );
+                    }
+                }
+            }
+        })
+    }
+
+    /// (a, b) を正規化（min < max）してペアの重複登録を防ぐ
+    fn canonical_pair(a: Uuid, b: Uuid) -> (Uuid, Uuid) {
+        if a < b {
+            (a, b)
+        } else {
+            (b, a)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// テスト
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> KeyExchangeConfig {
+        KeyExchangeConfig {
+            key_lifetime_hours: 24,
+            grace_period_hours: 1,
+            message_ttl_secs: 300,
+        }
+    }
+
+    /// プラグイン登録 → 鍵交換 → 暗号化 → 復号 の E2E ラウンドトリップ
+    #[tokio::test]
+    async fn test_key_exchange_roundtrip() {
+        let protocol = KeyExchangeProtocol::new_with_config(default_config());
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        protocol.register_plugin(plugin_b).await.unwrap();
+
+        protocol
+            .initiate_key_exchange(plugin_a, plugin_b)
+            .await
+            .unwrap();
+
+        let original = b"plugin-to-plugin secret message";
+        let payload = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, original)
+            .await
+            .unwrap();
+
+        assert_ne!(payload.ciphertext, original.to_vec());
+        assert_ne!(payload.nonce, [0u8; 12]);
+        assert_eq!(payload.signature.len(), 64);
+        assert!(payload.expires_at > payload.timestamp);
+
+        let decrypted = protocol
+            .decrypt_from_peer(plugin_b, plugin_a, &payload)
+            .await
+            .unwrap();
+
+        assert_eq!(decrypted, original.to_vec());
+    }
+
+    /// 双方向通信: B→A の暗号化と A での復号
+    #[tokio::test]
+    async fn test_bidirectional_encryption() {
+        let protocol = KeyExchangeProtocol::new_with_config(default_config());
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        protocol.register_plugin(plugin_b).await.unwrap();
+        protocol
+            .initiate_key_exchange(plugin_a, plugin_b)
+            .await
+            .unwrap();
+
+        // A → B
+        let msg_ab = b"A says hello to B";
+        let enc_ab = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, msg_ab)
+            .await
+            .unwrap();
+        let dec_ab = protocol
+            .decrypt_from_peer(plugin_b, plugin_a, &enc_ab)
+            .await
+            .unwrap();
+        assert_eq!(dec_ab, msg_ab.to_vec());
+
+        // B → A
+        let msg_ba = b"B replies to A";
+        let enc_ba = protocol
+            .encrypt_for_peer(plugin_b, plugin_a, msg_ba)
+            .await
+            .unwrap();
+        let dec_ba = protocol
+            .decrypt_from_peer(plugin_a, plugin_b, &enc_ba)
+            .await
+            .unwrap();
+        assert_eq!(dec_ba, msg_ba.to_vec());
+    }
+
+    /// 改ざん検出: 暗号文を変更すると Ed25519 署名検証が失敗する
+    #[tokio::test]
+    async fn test_tampered_payload_detection() {
+        let protocol = KeyExchangeProtocol::new_with_config(default_config());
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        protocol.register_plugin(plugin_b).await.unwrap();
+        protocol
+            .initiate_key_exchange(plugin_a, plugin_b)
+            .await
+            .unwrap();
+
+        let original = b"sensitive data";
+        let mut payload = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, original)
+            .await
+            .unwrap();
+
+        // 暗号文の先頭バイトを反転して改ざんを模倣
+        payload.ciphertext[0] ^= 0xFF;
+
+        let result = protocol
+            .decrypt_from_peer(plugin_b, plugin_a, &payload)
+            .await;
+        assert!(result.is_err(), "改ざんされたペイロードは復号に失敗するべき");
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(
+            err.contains("signature verification failed") || err.contains("SecurityFailure"),
+            "エラーは署名検証失敗を示すべき: {err}"
+        );
+    }
+
+    /// nonce ユニーク性: 同一プラグインペアでも毎回異なる nonce が生成される
+    #[tokio::test]
+    async fn test_nonce_uniqueness() {
+        let protocol = KeyExchangeProtocol::new_with_config(default_config());
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        protocol.register_plugin(plugin_b).await.unwrap();
+        protocol
+            .initiate_key_exchange(plugin_a, plugin_b)
+            .await
+            .unwrap();
+
+        let p1 = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, b"msg1")
+            .await
+            .unwrap();
+        let p2 = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, b"msg2")
+            .await
+            .unwrap();
+
+        assert_ne!(
+            p1.nonce, p2.nonce,
+            "各暗号化は一意な nonce を持つべき（リプレイ攻撃対策）"
+        );
+    }
+
+    /// セッションローテーション後も新しい鍵で正常に通信できる
+    #[tokio::test]
+    async fn test_session_rotation() {
+        let protocol = KeyExchangeProtocol::new_with_config(default_config());
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        protocol.register_plugin(plugin_b).await.unwrap();
+        protocol
+            .initiate_key_exchange(plugin_a, plugin_b)
+            .await
+            .unwrap();
+
+        let old_payload = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, b"before rotation")
+            .await
+            .unwrap();
+
+        protocol.rotate_session(plugin_a, plugin_b).await.unwrap();
+
+        // ローテーション後も新しい鍵で通信できる
+        let msg = b"after rotation";
+        let new_payload = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, msg)
+            .await
+            .unwrap();
+        let dec = protocol
+            .decrypt_from_peer(plugin_b, plugin_a, &new_payload)
+            .await
+            .unwrap();
+        assert_eq!(dec, msg.to_vec());
+
+        // ECDH 公開鍵が更新されていること（PFS の確認）
+        assert_ne!(
+            old_payload.sender_ecdh_public_key,
+            new_payload.sender_ecdh_public_key,
+            "セッションローテーション後は ECDH 公開鍵が更新されるべき"
+        );
+    }
+
+    /// 未登録プラグインへの鍵交換はエラーになる
+    #[tokio::test]
+    async fn test_unregistered_plugin_exchange_fails() {
+        let protocol = KeyExchangeProtocol::new_with_config(default_config());
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        // plugin_b は未登録
+
+        let result = protocol.initiate_key_exchange(plugin_a, plugin_b).await;
+        assert!(
+            result.is_err(),
+            "未登録プラグインとの鍵交換はエラーになるべき"
+        );
+    }
+
+    /// グレースピリオドテスト: ローテーション後も旧鍵で暗号化されたメッセージを復号できる
+    ///
+    /// ローリングデプロイや遅延メッセージのシナリオを想定。
+    #[tokio::test]
+    async fn test_grace_period_allows_decryption_with_old_key() {
+        let protocol = KeyExchangeProtocol::new_with_config(KeyExchangeConfig {
+            key_lifetime_hours: 24,
+            grace_period_hours: 1, // 1 時間のグレースピリオド
+            message_ttl_secs: 300,
+        });
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        protocol.register_plugin(plugin_b).await.unwrap();
+
+        // 初回鍵交換 (K1 を確立)
+        protocol
+            .initiate_key_exchange(plugin_a, plugin_b)
+            .await
+            .unwrap();
+
+        // K1 でメッセージを暗号化（ローテーション前）
+        let original = b"sent before key rotation";
+        let payload_with_k1 = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, original)
+            .await
+            .unwrap();
+
+        // セッションをローテーション: K1 → secondary (grace period), K2 → primary
+        protocol.rotate_session(plugin_a, plugin_b).await.unwrap();
+
+        // B は K1 で暗号化されたメッセージをグレースピリオド内に復号できる
+        // (primary K2 で失敗 → secondary K1 でフォールバック)
+        let decrypted = protocol
+            .decrypt_from_peer(plugin_b, plugin_a, &payload_with_k1)
+            .await
+            .expect("グレースピリオド内は旧鍵で復号できるべき");
+        assert_eq!(decrypted, original.to_vec());
+
+        // ローテーション後の新しいメッセージ (K2) も正常に復号できる
+        let new_msg = b"sent after key rotation";
+        let payload_with_k2 = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, new_msg)
+            .await
+            .unwrap();
+        let dec_new = protocol
+            .decrypt_from_peer(plugin_b, plugin_a, &payload_with_k2)
+            .await
+            .unwrap();
+        assert_eq!(dec_new, new_msg.to_vec());
+    }
+
+    /// タイムスタンプ期限切れテスト: expires_at を過去に設定したペイロードは復号拒否
+    ///
+    /// リプレイ攻撃シミュレーション: 古いメッセージを再送しても拒否されることを確認。
+    #[tokio::test]
+    async fn test_expired_message_rejected() {
+        let protocol = KeyExchangeProtocol::new_with_config(default_config());
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        protocol.register_plugin(plugin_b).await.unwrap();
+        protocol
+            .initiate_key_exchange(plugin_a, plugin_b)
+            .await
+            .unwrap();
+
+        // 通常どおり暗号化
+        let mut payload = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, b"time-sensitive message")
+            .await
+            .unwrap();
+
+        // expires_at を過去に設定（リプレイメッセージを模倣）
+        payload.expires_at = Utc::now().timestamp() - 1;
+
+        let result = protocol
+            .decrypt_from_peer(plugin_b, plugin_a, &payload)
+            .await;
+        assert!(result.is_err(), "期限切れメッセージは復号を拒否されるべき");
+        let err = format!("{:?}", result.unwrap_err());
+        assert!(
+            err.contains("expired") || err.contains("SecurityFailure"),
+            "エラーは期限切れを示すべき: {err}"
+        );
+    }
+
+    /// 自動ローテーションタスクのライフサイクルテスト
+    ///
+    /// タスクが正常に起動し、`abort()` で停止できることを確認する。
+    #[tokio::test]
+    async fn test_auto_rotation_task_lifecycle() {
+        let protocol = Arc::new(KeyExchangeProtocol::new_with_config(default_config()));
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        protocol.register_plugin(plugin_b).await.unwrap();
+        protocol
+            .initiate_key_exchange(plugin_a, plugin_b)
+            .await
+            .unwrap();
+
+        let handle = KeyExchangeProtocol::start_auto_rotation(Arc::clone(&protocol));
+
+        // タイマーが発火していない（24 時間待ち）のでタスクは実行中のはず
+        assert!(!handle.is_finished(), "自動ローテーションタスクは実行中のはず");
+
+        // 正常に停止できることを確認
+        handle.abort();
+        let result = handle.await;
+        assert!(result.is_err(), "abort() 後は JoinError になるはず");
+    }
+
+    /// 自動ローテーション時刻制御テスト
+    ///
+    /// tokio::time pause + advance でタイマーを仮想的に進め、
+    /// ローテーションタスクが発火した後もプロトコルが正常動作することを確認する。
+    ///
+    /// ## 検証内容
+    /// - タイマー発火後に abort() せず次のループ Sleep に入れること
+    /// - ローテーション有無に関わらずグレースピリオドで送受信継続できること
+    /// - `test_session_rotation` で鍵変更の正確性は別途保証済み
+    #[tokio::test(start_paused = true)]
+    async fn test_auto_rotation_fires_on_schedule() {
+        let protocol = Arc::new(KeyExchangeProtocol::new_with_config(KeyExchangeConfig {
+            key_lifetime_hours: 1, // テスト用に 1 時間
+            grace_period_hours: 1,
+            message_ttl_secs: 300,
+        }));
+        let plugin_a = Uuid::new_v4();
+        let plugin_b = Uuid::new_v4();
+
+        protocol.register_plugin(plugin_a).await.unwrap();
+        protocol.register_plugin(plugin_b).await.unwrap();
+        protocol
+            .initiate_key_exchange(plugin_a, plugin_b)
+            .await
+            .unwrap();
+
+        // ローテーション前のメッセージを暗号化（グレースピリオドテスト用）
+        let pre_rotation_msg = b"before rotation";
+        let pre_payload = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, pre_rotation_msg)
+            .await
+            .unwrap();
+
+        let handle = KeyExchangeProtocol::start_auto_rotation(Arc::clone(&protocol));
+
+        // タスクが起動直後は sleep 中なのでまだ終了していない
+        assert!(!handle.is_finished(), "自動ローテーションタスクは実行中のはず");
+
+        // 仮想時間を 1 時間 + α だけ進めてタイマーを発火させる
+        tokio::time::advance(tokio::time::Duration::from_secs(3601)).await;
+        // 非同期タスクが rotate_session() を実行する機会を与える
+        for _ in 0..100 {
+            tokio::task::yield_now().await;
+        }
+
+        handle.abort();
+        let _ = handle.await;
+
+        // ローテーション後も新メッセージを送受信できる
+        // （ローテーションが実際に行われた場合は新鍵、Grace Period で旧鍵も使用可能）
+        let post_msg = b"after rotation";
+        let post_payload = protocol
+            .encrypt_for_peer(plugin_a, plugin_b, post_msg)
+            .await
+            .unwrap();
+        let dec = protocol
+            .decrypt_from_peer(plugin_b, plugin_a, &post_payload)
+            .await
+            .expect("ローテーション後も新しいメッセージを復号できるべき");
+        assert_eq!(dec, post_msg.to_vec());
+
+        // グレースピリオドにより、ローテーション前のメッセージも復号できる
+        let dec_pre = protocol
+            .decrypt_from_peer(plugin_b, plugin_a, &pre_payload)
+            .await
+            .expect("グレースピリオド内は旧メッセージを復号できるべき");
+        assert_eq!(dec_pre, pre_rotation_msg.to_vec());
+    }
+}

--- a/src/plugin_isolation/key_exchange.rs
+++ b/src/plugin_isolation/key_exchange.rs
@@ -230,25 +230,21 @@ impl PluginCryptoContext {
     /// 2. `expires_at` 期限チェック（リプレイ攻撃対策）
     /// 3. プライマリ鍵で ChaCha20-Poly1305 復号
     /// 4. 失敗時: グレースピリオド内であればセカンダリ鍵（旧鍵）で再試行
-    pub fn decrypt(
-        &self,
-        peer_id: Uuid,
-        payload: &EncryptedPayload,
-    ) -> Result<Vec<u8>, McpError> {
+    pub fn decrypt(&self, peer_id: Uuid, payload: &EncryptedPayload) -> Result<Vec<u8>, McpError> {
         let session = self.get_valid_session(peer_id)?;
 
         // 1. Ed25519 署名検証（改ざん検知 — 復号前に必ず実施）
         let verifying_key = VerifyingKey::from_bytes(&session.peer_verifying_key)
             .map_err(|e| McpError::SecurityFailure(format!("Invalid peer verifying key: {e}")))?;
-        let sig_bytes: [u8; 64] = payload
-            .signature
-            .as_slice()
-            .try_into()
-            .map_err(|_| McpError::SecurityFailure("Invalid Ed25519 signature length".to_string()))?;
-        let sig = Signature::from_bytes(&sig_bytes);
-        verifying_key.verify(&payload.ciphertext, &sig).map_err(|_| {
-            McpError::SecurityFailure("Ed25519 signature verification failed".to_string())
+        let sig_bytes: [u8; 64] = payload.signature.as_slice().try_into().map_err(|_| {
+            McpError::SecurityFailure("Invalid Ed25519 signature length".to_string())
         })?;
+        let sig = Signature::from_bytes(&sig_bytes);
+        verifying_key
+            .verify(&payload.ciphertext, &sig)
+            .map_err(|_| {
+                McpError::SecurityFailure("Ed25519 signature verification failed".to_string())
+            })?;
 
         // 2. タイムスタンプ期限チェック（リプレイ攻撃対策）
         let now_ts = Utc::now().timestamp();
@@ -565,10 +561,7 @@ impl KeyExchangeProtocol {
 
                 for (a, b) in pairs {
                     if let Err(e) = protocol.rotate_session(a, b).await {
-                        warn!(
-                            "Auto key rotation failed for pair ({}, {}): {}",
-                            a, b, e
-                        );
+                        warn!("Auto key rotation failed for pair ({}, {}): {}", a, b, e);
                     }
                 }
             }
@@ -700,7 +693,10 @@ mod tests {
         let result = protocol
             .decrypt_from_peer(plugin_b, plugin_a, &payload)
             .await;
-        assert!(result.is_err(), "改ざんされたペイロードは復号に失敗するべき");
+        assert!(
+            result.is_err(),
+            "改ざんされたペイロードは復号に失敗するべき"
+        );
         let err = format!("{:?}", result.unwrap_err());
         assert!(
             err.contains("signature verification failed") || err.contains("SecurityFailure"),
@@ -772,8 +768,7 @@ mod tests {
 
         // ECDH 公開鍵が更新されていること（PFS の確認）
         assert_ne!(
-            old_payload.sender_ecdh_public_key,
-            new_payload.sender_ecdh_public_key,
+            old_payload.sender_ecdh_public_key, new_payload.sender_ecdh_public_key,
             "セッションローテーション後は ECDH 公開鍵が更新されるべき"
         );
     }
@@ -903,7 +898,10 @@ mod tests {
         let handle = KeyExchangeProtocol::start_auto_rotation(Arc::clone(&protocol));
 
         // タイマーが発火していない（24 時間待ち）のでタスクは実行中のはず
-        assert!(!handle.is_finished(), "自動ローテーションタスクは実行中のはず");
+        assert!(
+            !handle.is_finished(),
+            "自動ローテーションタスクは実行中のはず"
+        );
 
         // 正常に停止できることを確認
         handle.abort();
@@ -947,7 +945,10 @@ mod tests {
         let handle = KeyExchangeProtocol::start_auto_rotation(Arc::clone(&protocol));
 
         // タスクが起動直後は sleep 中なのでまだ終了していない
-        assert!(!handle.is_finished(), "自動ローテーションタスクは実行中のはず");
+        assert!(
+            !handle.is_finished(),
+            "自動ローテーションタスクは実行中のはず"
+        );
 
         // 仮想時間を 1 時間 + α だけ進めてタイマーを発火させる
         tokio::time::advance(tokio::time::Duration::from_secs(3601)).await;

--- a/src/plugin_isolation/mod.rs
+++ b/src/plugin_isolation/mod.rs
@@ -9,6 +9,7 @@ pub mod error_handler;
 mod health;
 pub mod inter_plugin_comm;
 pub mod isolation_engine;
+pub mod key_exchange;
 pub mod lifecycle_manager;
 mod manager;
 pub mod monitoring;
@@ -21,6 +22,7 @@ pub use communication_broker::{
     CommunicationBroker, CommunicationChannel, EncryptionAlgorithm, FilterAction, FilterType,
     MessageFilter, MessageType, RateLimitConfig,
 };
+pub use key_exchange::{EncryptedPayload, KeyExchangeConfig, KeyExchangeProtocol, PluginCryptoContext};
 pub use config::{
     AlertThresholds, IsolationConfig, MonitoringConfig, PluginManagerConfig, SecurityPolicy,
 };

--- a/src/plugin_isolation/mod.rs
+++ b/src/plugin_isolation/mod.rs
@@ -22,7 +22,6 @@ pub use communication_broker::{
     CommunicationBroker, CommunicationChannel, EncryptionAlgorithm, FilterAction, FilterType,
     MessageFilter, MessageType, RateLimitConfig,
 };
-pub use key_exchange::{EncryptedPayload, KeyExchangeConfig, KeyExchangeProtocol, PluginCryptoContext};
 pub use config::{
     AlertThresholds, IsolationConfig, MonitoringConfig, PluginManagerConfig, SecurityPolicy,
 };
@@ -34,6 +33,9 @@ pub use health::PluginManagerHealth;
 pub use inter_plugin_comm::{
     CommEventType, CommResult, CommunicationEvent, CommunicationRule, InterPluginCommConfig,
     InterPluginCommStats, InterPluginCommunicationController, QueuedMessage, RuleStatus,
+};
+pub use key_exchange::{
+    EncryptedPayload, KeyExchangeConfig, KeyExchangeProtocol, PluginCryptoContext,
 };
 pub use manager::IsolatedPluginManager;
 pub use monitoring::{


### PR DESCRIPTION
## 概要
Issue #225 の未完了項目だった以下 3 点を実装しました。
- 自動キーローテーション
- ローテーション時のグレースピリオド
- メッセージ有効期限（timestamp / expires_at）検証

あわせて、`key_exchange` 専用モジュールを復元・拡張し、`communication_broker` 側に設定連携を行っています。

## 変更内容
- `src/plugin_isolation/key_exchange.rs` を新規追加（拡張実装）
  - `KeyExchangeConfig` を追加（key lifetime / grace period / message TTL）
  - `EncryptedPayload` に `timestamp`, `expires_at` を追加
  - `SessionKey` に `secondary_key`, `secondary_expires_at` を追加
  - 復号時に期限切れメッセージを拒否
  - 復号時に primary 失敗時 secondary（grace period）へフォールバック
  - `start_auto_rotation` によるバックグラウンド自動ローテーション
- `src/plugin_isolation/communication_broker.rs`
  - `key_rotation` 設定から `KeyExchangeConfig` を組み立てて連携
  - `auto_rotation_enabled=true` の場合に自動ローテーション起動
- `src/plugin_isolation/mod.rs`
  - `KeyExchangeConfig` を `pub use` に追加

## テスト
`cargo test --lib -- plugin_isolation`
- 結果: 40 passed / 0 failed

追加・更新した主な `key_exchange` テスト:
- `test_grace_period_allows_decryption_with_old_key`
- `test_expired_message_rejected`
- `test_auto_rotation_task_lifecycle`
- `test_auto_rotation_fires_on_schedule`

Closes #225