### PR TITLE
feat(#266): WordPress サイト一括構築デモ examples/wordpress_site_builder_demo.rs の追加

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -40,4 +40,18 @@ ignore = [
     # - Mitigation: Only used by optional ml-anomaly-detection feature
     "RUSTSEC-2024-0436",
 
+    # RUSTSEC-2026-0118: hickory-proto NSEC3 closest-encloser proof validation unbounded loop
+    # - Affects: hickory-proto (all versions including 0.26.1)
+    # - Status: No fixed upgrade is available
+    # - Mitigation: mcp-rs uses hickory-resolver for DNS resolution only (no DNSSEC validation)
+    #               NSEC3 processing path is not invoked in typical stub resolver usage
+    "RUSTSEC-2026-0118",
+
+    # RUSTSEC-2026-0119: hickory-proto CPU exhaustion due to O(n²) name compression
+    # - Affects: hickory-proto 0.25.2 via mongodb 3.6.0 (transitive dependency)
+    # - Status: Fixed in >= 0.26.1; direct dependency updated, but mongodb pins 0.25.2 internally
+    # - Mitigation: mongodb is optional (mongodb-backend feature); message encoding path
+    #               is not exposed externally; track mongodb release with updated hickory
+    "RUSTSEC-2026-0119",
+
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -726,7 +726,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -736,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -978,6 +989,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,7 +1201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1992,9 +2012,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2169,23 +2203,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto 0.26.1",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.17",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2218,24 +2252,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.24.4"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto 0.24.4",
- "ipconfig",
- "lru-cache",
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
  "once_cell",
- "parking_lot",
- "rand 0.8.5",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.17",
+ "tinyvec",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2254,6 +2287,32 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2588,6 +2647,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2770,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -2768,6 +2836,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
  "quote",
  "syn",
 ]
@@ -3021,6 +3138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,12 +3199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,15 +3232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -3268,7 +3376,7 @@ dependencies = [
  "futures",
  "futures-util",
  "governor",
- "hickory-resolver 0.24.4",
+ "hickory-resolver 0.26.1",
  "http",
  "hyper",
  "hyper-util",
@@ -3484,9 +3592,9 @@ checksum = "224484c5d09285a7b8cb0a0c117e847ebd14cb6e4470ecf68cdb89c503b0edb9"
 
 [[package]]
 name = "mongodb"
-version = "3.4.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f5c20217413bed97c613714e6d6dfe39ef59dd79a68999f1043b0566192975"
+checksum = "1ef2c933617431ad0246fb5b43c425ebdae18c7f7259c87de0726d93b0e7e91b"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.10.0",
@@ -3530,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb-internal-macros"
-version = "3.4.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20033442aa13664e70bc9f8be1bacabebf6a31b6d4bb5608ceb99c4ec96e9951"
+checksum = "9e5758dc828eb2d02ec30563cba365609d56ddd833190b192beaee2b475a7bb3"
 dependencies = [
  "macro_magic",
  "proc-macro2",
@@ -3681,6 +3789,12 @@ dependencies = [
  "num-traits",
  "rawpointer",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -4274,7 +4388,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4286,7 +4400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4393,6 +4507,27 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -4600,6 +4735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4624,6 +4765,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4663,6 +4815,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -5433,7 +5591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5450,7 +5608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5527,6 +5685,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5903,6 +6077,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6707,7 +6902,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -6775,6 +6979,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.12.1",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6785,6 +7011,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.12.1",
+ "semver",
 ]
 
 [[package]]
@@ -7200,6 +7438,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.12.1",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.12.1",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.12.1",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ mysql_async = { version = "0.36", optional = true }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1"], optional = true }
 redis = { version = "0.26", features = ["tokio-comp", "connection-manager"], optional = true }
 # MongoDB support
-mongodb = { version = "3.1", optional = true }
+mongodb = { version = "3.6", optional = true }
 
 # Date and time
 chrono = { version = "0.4", features = ["serde"] }
@@ -81,7 +81,7 @@ qrcode = { version = "0.14", optional = true }
 
 # Network and IP handling
 ipnet = "2.11"
-hickory-resolver = { version = "0.24.4", optional = true }
+hickory-resolver = { version = "0.26.1", optional = true }
 
 # Logging and tracing
 tracing = "0.1.41"

--- a/benches/mysql_performance_benchmark.rs
+++ b/benches/mysql_performance_benchmark.rs
@@ -212,7 +212,7 @@ impl MySqlPerformanceBenchmark {
             metrics.total_queries += 1;
 
             // Progress indicator
-            if metrics.total_queries % 100 == 0 {
+            if metrics.total_queries.is_multiple_of(100) {
                 println!("  Completed {} queries", metrics.total_queries);
             }
         }
@@ -239,29 +239,33 @@ impl MySqlPerformanceBenchmark {
         let mut query_times = Vec::new();
 
         // Test different parameter types and complexities
-        let test_queries = vec![
+        let simple1 = [Value::from_i64(42)];
+        let simple2 = [Value::String("test_string".to_string())];
+        let simple3 = [Value::from_bool(true)];
+        let simple4 = [Value::Float(std::f64::consts::PI)];
+        let multi = [
+            Value::from_i64(1),
+            Value::String("multi".to_string()),
+            Value::from_bool(false),
+            Value::Float(std::f64::consts::E),
+        ];
+        let complex = [
+            Value::from_i64(100),
+            Value::String("complex_test".to_string()),
+            Value::from_bool(true),
+            Value::Float(95.5),
+            Value::from_bool(true),
+        ];
+        let test_queries: &[(&str, &[Value])] = &[
             // Simple parameterized queries
-            ("SELECT ? as int_param", vec![Value::from_i64(42)]),
-            ("SELECT ? as string_param", vec![Value::String("test_string".to_string())]),
-            ("SELECT ? as bool_param", vec![Value::from_bool(true)]),
-            ("SELECT ? as float_param", vec![Value::Float(std::f64::consts::PI)]),
-
+            ("SELECT ? as int_param", &simple1),
+            ("SELECT ? as string_param", &simple2),
+            ("SELECT ? as bool_param", &simple3),
+            ("SELECT ? as float_param", &simple4),
             // Multiple parameters
-            ("SELECT ?, ?, ?, ? as multi_params", vec![
-                Value::from_i64(1),
-                Value::String("multi".to_string()),
-                Value::from_bool(false),
-                Value::Float(std::f64::consts::E)
-            ]),
-
+            ("SELECT ?, ?, ?, ? as multi_params", &multi),
             // Complex queries with parameters
-            ("SELECT * FROM (SELECT ? as id, ? as name, ? as active, ? as score) as sub WHERE sub.active = ?", vec![
-                Value::from_i64(100),
-                Value::String("complex_test".to_string()),
-                Value::from_bool(true),
-                Value::Float(95.5),
-                Value::from_bool(true)
-            ]),
+            ("SELECT * FROM (SELECT ? as id, ? as name, ? as active, ? as score) as sub WHERE sub.active = ?", &complex),
         ];
 
         let benchmark_start = Instant::now();

--- a/examples/wordpress_site_builder_demo.rs
+++ b/examples/wordpress_site_builder_demo.rs
@@ -72,8 +72,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     // 環境変数から認証情報を取得
-    let wp_url =
+    let wp_url_raw =
         env::var("WORDPRESS_URL").unwrap_or_else(|_| "https://your-site.example.com".to_string());
+    // /wp-json の二重付与を防ぐため、末尾スラッシュと /wp-json を正規化する
+    let wp_url = wp_url_raw
+        .trim_end_matches('/')
+        .strip_suffix("/wp-json")
+        .unwrap_or(wp_url_raw.trim_end_matches('/'))
+        .to_string();
     let wp_username = env::var("WORDPRESS_USERNAME").unwrap_or_default();
     let wp_password = env::var("WORDPRESS_PASSWORD").unwrap_or_default();
 
@@ -89,7 +95,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("👤 ユーザー: {}", wp_username);
     println!();
 
-    let handler = WordPressHandler::new(WordPressConfig {
+    let handler = WordPressHandler::try_new(WordPressConfig {
         url: wp_url,
         username: wp_username,
         password: wp_password,
@@ -97,7 +103,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         timeout_seconds: Some(30),
         rate_limit: None,
         encrypted_credentials: None,
-    });
+    })
+    .map_err(|e| format!("WordPress ハンドラーの初期化に失敗しました: {}", e))?;
 
     // ── Step 1: ヘルスチェック ──────────────────────────────────────────────
     print!("[1/6] 🔍 WordPress 接続確認... ");
@@ -147,8 +154,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("   ⚠️  「{}」スキップ（IDが取得できませんでした）", name);
                 }
             }
-            Err(e) => {
-                println!("   ⚠️  「{}」スキップ（既存の可能性）: {}", name, e);
+            Err(_) => {
+                // 既存のカテゴリの場合、一覧から名前でIDを解決する
+                if let Ok(existing) = handler.get_categories().await {
+                    if let Some(cat) = existing.iter().find(|c| c.name == *name) {
+                        if let Some(id) = cat.id {
+                            println!("   ♻️  「{}」既存を利用 (ID: {})", name, id);
+                            category_ids.push((name.to_string(), id));
+                        }
+                    }
+                }
             }
         }
         sleep(Duration::from_millis(200)).await;
@@ -167,8 +182,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("   ⚠️  「{}」スキップ（IDが取得できませんでした）", name);
                 }
             }
-            Err(e) => {
-                println!("   ⚠️  「{}」スキップ: {}", name, e);
+            Err(_) => {
+                // 既存のタグの場合、一覧から名前でIDを解決する
+                if let Ok(existing) = handler.get_tags().await {
+                    if let Some(tag) = existing.iter().find(|t| t.name == *name) {
+                        if let Some(id) = tag.id {
+                            println!("   ♻️  「{}」既存を利用 (ID: {})", name, id);
+                            tag_ids.push((name.to_string(), id));
+                        }
+                    }
+                }
             }
         }
         sleep(Duration::from_millis(200)).await;

--- a/examples/wordpress_site_builder_demo.rs
+++ b/examples/wordpress_site_builder_demo.rs
@@ -29,6 +29,7 @@ use mcp_rs::{
     config::WordPressConfig,
     handlers::wordpress::{PostCreateParams, SettingsUpdateParams, WordPressHandler},
 };
+use std::collections::HashSet;
 use std::env;
 use tokio::time::{sleep, Duration};
 
@@ -95,6 +96,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("👤 ユーザー: {}", wp_username);
     println!();
 
+    let mut warning_count = 0usize;
+
     let handler = WordPressHandler::try_new(WordPressConfig {
         url: wp_url,
         username: wp_username,
@@ -121,6 +124,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for err in &health.error_details {
             eprintln!("     {}", err);
         }
+        eprintln!("❌ ヘルスチェックで問題が検出されたため、Step 2 以降を中止します。");
+        return Ok(());
     }
 
     // ── Step 2: サイト設定 ──────────────────────────────────────────────────
@@ -144,26 +149,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Step 3: カテゴリ作成 ────────────────────────────────────────────────
     println!("[3/6] 🏷️  カテゴリを作成中...");
     let mut category_ids: Vec<(String, u64)> = Vec::new();
+    let existing_categories = handler.get_categories().await?;
     for (name, desc) in CATEGORIES {
+        if let Some(existing) = existing_categories.iter().find(|c| c.name == *name) {
+            if let Some(id) = existing.id {
+                println!("   ♻️  「{}」既存を利用 (ID: {})", name, id);
+                category_ids.push((name.to_string(), id));
+                sleep(Duration::from_millis(200)).await;
+                continue;
+            }
+            return Err(std::io::Error::other(format!(
+                "カテゴリ「{}」の既存IDが取得できませんでした",
+                name
+            ))
+            .into());
+        }
+
         match handler.create_category(name, Some(desc), None).await {
             Ok(cat) => {
                 if let Some(id) = cat.id {
                     println!("   ✅ 「{}」(ID: {})", name, id);
                     category_ids.push((name.to_string(), id));
                 } else {
-                    println!("   ⚠️  「{}」スキップ（IDが取得できませんでした）", name);
+                    return Err(std::io::Error::other(format!(
+                        "カテゴリ「{}」の作成後にIDが取得できませんでした",
+                        name
+                    ))
+                    .into());
                 }
             }
-            Err(_) => {
-                // 既存のカテゴリの場合、一覧から名前でIDを解決する
-                if let Ok(existing) = handler.get_categories().await {
-                    if let Some(cat) = existing.iter().find(|c| c.name == *name) {
-                        if let Some(id) = cat.id {
-                            println!("   ♻️  「{}」既存を利用 (ID: {})", name, id);
-                            category_ids.push((name.to_string(), id));
-                        }
-                    }
-                }
+            Err(e) => {
+                return Err(std::io::Error::other(format!(
+                    "カテゴリ「{}」の作成に失敗しました: {}",
+                    name, e
+                ))
+                .into());
             }
         }
         sleep(Duration::from_millis(200)).await;
@@ -172,26 +192,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Step 4: タグ作成 ────────────────────────────────────────────────────
     println!("[4/6] 🔖 タグを作成中...");
     let mut tag_ids: Vec<(String, u64)> = Vec::new();
+    let existing_tags = handler.get_tags().await?;
     for (name, desc) in TAGS {
+        if let Some(existing) = existing_tags.iter().find(|t| t.name == *name) {
+            if let Some(id) = existing.id {
+                println!("   ♻️  「{}」既存を利用 (ID: {})", name, id);
+                tag_ids.push((name.to_string(), id));
+                sleep(Duration::from_millis(200)).await;
+                continue;
+            }
+            return Err(std::io::Error::other(format!(
+                "タグ「{}」の既存IDが取得できませんでした",
+                name
+            ))
+            .into());
+        }
+
         match handler.create_tag(name, Some(desc)).await {
             Ok(tag) => {
                 if let Some(id) = tag.id {
                     println!("   ✅ 「{}」(ID: {})", name, id);
                     tag_ids.push((name.to_string(), id));
                 } else {
-                    println!("   ⚠️  「{}」スキップ（IDが取得できませんでした）", name);
+                    return Err(std::io::Error::other(format!(
+                        "タグ「{}」の作成後にIDが取得できませんでした",
+                        name
+                    ))
+                    .into());
                 }
             }
-            Err(_) => {
-                // 既存のタグの場合、一覧から名前でIDを解決する
-                if let Ok(existing) = handler.get_tags().await {
-                    if let Some(tag) = existing.iter().find(|t| t.name == *name) {
-                        if let Some(id) = tag.id {
-                            println!("   ♻️  「{}」既存を利用 (ID: {})", name, id);
-                            tag_ids.push((name.to_string(), id));
-                        }
-                    }
-                }
+            Err(e) => {
+                return Err(std::io::Error::other(format!(
+                    "タグ「{}」の作成に失敗しました: {}",
+                    name, e
+                ))
+                .into());
             }
         }
         sleep(Duration::from_millis(200)).await;
@@ -199,7 +234,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Step 5: 固定ページ作成 ──────────────────────────────────────────────
     println!("[5/6] 📄 固定ページを作成中...");
+    let (existing_posts, existing_pages) = handler.get_all_content().await?;
+    let mut existing_page_titles: HashSet<String> = existing_pages
+        .iter()
+        .map(|p| normalize_title(&p.title.rendered))
+        .collect();
+    let mut existing_post_titles: HashSet<String> = existing_posts
+        .iter()
+        .map(|p| normalize_title(&p.title.rendered))
+        .collect();
+
     for (title, content) in sample_pages() {
+        if existing_page_titles.contains(&normalize_title(&title)) {
+            println!("   ♻️  「{}」既存を利用", title);
+            sleep(Duration::from_millis(200)).await;
+            continue;
+        }
+
         match handler
             .create_advanced_post(PostCreateParams {
                 title: title.clone(),
@@ -214,8 +265,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             })
             .await
         {
-            Ok(page) => println!("   ✅ 「{}」(ID: {})", title, page.id.unwrap_or(0)),
-            Err(e) => println!("   ⚠️  「{}」スキップ: {}", title, e),
+            Ok(page) => {
+                println!("   ✅ 「{}」(ID: {})", title, page.id.unwrap_or(0));
+                existing_page_titles.insert(normalize_title(&title));
+            }
+            Err(e) => {
+                warning_count += 1;
+                println!("   ⚠️  「{}」作成失敗: {}", title, e);
+            }
         }
         sleep(Duration::from_millis(400)).await;
     }
@@ -233,6 +290,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         |name: &str| -> Option<u64> { tag_ids.iter().find(|(n, _)| n == name).map(|(_, id)| *id) };
 
     for (title, content, cats, tags) in sample_posts(&find_cat, &find_tag) {
+        if existing_post_titles.contains(&normalize_title(&title)) {
+            println!("   ♻️  「{}」既存を利用", title);
+            sleep(Duration::from_millis(200)).await;
+            continue;
+        }
+
+        if cats.is_empty() || tags.is_empty() {
+            return Err(std::io::Error::other(format!(
+                "投稿「{}」に必要なカテゴリまたはタグのIDが解決できませんでした",
+                title
+            ))
+            .into());
+        }
+
+        let categories = if cats.is_empty() { None } else { Some(cats) };
+        let tags = if tags.is_empty() { None } else { Some(tags) };
         match handler
             .create_advanced_post(PostCreateParams {
                 title: title.clone(),
@@ -240,25 +313,46 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 post_type: "post".to_string(),
                 status: "publish".to_string(),
                 date: None,
-                categories: Some(cats),
-                tags: Some(tags),
+                categories,
+                tags,
                 featured_media_id: None,
                 meta: None,
             })
             .await
         {
-            Ok(post) => println!("   ✅ 「{}」(ID: {})", title, post.id.unwrap_or(0)),
-            Err(e) => println!("   ⚠️  「{}」スキップ: {}", title, e),
+            Ok(post) => {
+                println!("   ✅ 「{}」(ID: {})", title, post.id.unwrap_or(0));
+                existing_post_titles.insert(normalize_title(&title));
+            }
+            Err(e) => {
+                warning_count += 1;
+                println!("   ⚠️  「{}」作成失敗: {}", title, e);
+            }
         }
         sleep(Duration::from_millis(400)).await;
     }
 
     println!();
-    println!("╔══════════════════════════════════════════════════════╗");
-    println!("║  🎉 サイト初期構築完了！                              ║");
-    println!("╚══════════════════════════════════════════════════════╝");
+    if warning_count == 0 {
+        println!("╔══════════════════════════════════════════════════════╗");
+        println!("║  🎉 サイト初期構築完了！                              ║");
+        println!("╚══════════════════════════════════════════════════════╝");
+    } else {
+        println!("╔══════════════════════════════════════════════════════╗");
+        println!("║  ⚠️  一部の処理で失敗が発生しました                    ║");
+        println!("╚══════════════════════════════════════════════════════╝");
+        return Err(std::io::Error::other(format!(
+            "{} 件の処理失敗が発生しました。ログを確認してください。",
+            warning_count
+        ))
+        .into());
+    }
 
     Ok(())
+}
+
+fn normalize_title(title: &str) -> String {
+    title.trim().to_lowercase()
 }
 
 /// サンプルの固定ページ: (タイトル, 本文HTML)

--- a/examples/wordpress_site_builder_demo.rs
+++ b/examples/wordpress_site_builder_demo.rs
@@ -27,8 +27,11 @@
 
 use mcp_rs::{
     config::WordPressConfig,
-    handlers::wordpress::{PostCreateParams, SettingsUpdateParams, WordPressHandler},
+    handlers::wordpress::{
+        PostCreateParams, SettingsUpdateParams, WordPressCategory, WordPressHandler, WordPressTag,
+    },
 };
+use reqwest::{Client, StatusCode};
 use std::collections::HashSet;
 use std::env;
 use std::io::{self, Write};
@@ -100,9 +103,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut warning_count = 0usize;
 
     let handler = WordPressHandler::try_new(WordPressConfig {
-        url: wp_url,
-        username: wp_username,
-        password: wp_password,
+        url: wp_url.clone(),
+        username: wp_username.clone(),
+        password: wp_password.clone(),
         enabled: Some(true),
         timeout_seconds: Some(30),
         rate_limit: None,
@@ -152,7 +155,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Step 3: カテゴリ作成 ────────────────────────────────────────────────
     println!("[3/6] 🏷️  カテゴリを作成中...");
     let mut category_ids: Vec<(String, u64)> = Vec::new();
-    let existing_categories = handler.get_categories().await?;
+    let existing_categories = fetch_all_categories(&wp_url, &wp_username, &wp_password).await?;
     for (name, desc) in CATEGORIES {
         if let Some(existing) = existing_categories.iter().find(|c| c.name == *name) {
             if let Some(id) = existing.id {
@@ -195,7 +198,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Step 4: タグ作成 ────────────────────────────────────────────────────
     println!("[4/6] 🔖 タグを作成中...");
     let mut tag_ids: Vec<(String, u64)> = Vec::new();
-    let existing_tags = handler.get_tags().await?;
+    let existing_tags = fetch_all_tags(&wp_url, &wp_username, &wp_password).await?;
     for (name, desc) in TAGS {
         if let Some(existing) = existing_tags.iter().find(|t| t.name == *name) {
             if let Some(id) = existing.id {
@@ -366,6 +369,90 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn normalize_title(title: &str) -> String {
     title.trim().to_lowercase()
+}
+
+async fn fetch_all_categories(
+    base_url: &str,
+    username: &str,
+    password: &str,
+) -> Result<Vec<WordPressCategory>, Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let mut all_categories: Vec<WordPressCategory> = Vec::new();
+    let mut page: u32 = 1;
+
+    loop {
+        let url = format!("{}/wp-json/wp/v2/categories", base_url);
+        let response = client
+            .get(&url)
+            .basic_auth(username, Some(password))
+            .query(&[("per_page", "100"), ("page", &page.to_string())])
+            .send()
+            .await?;
+
+        if response.status() == StatusCode::BAD_REQUEST && page > 1 {
+            break;
+        }
+
+        if !response.status().is_success() {
+            return Err(io::Error::other(format!(
+                "カテゴリ一覧の取得に失敗しました (status: {})",
+                response.status()
+            ))
+            .into());
+        }
+
+        let page_items: Vec<WordPressCategory> = response.json().await?;
+        if page_items.is_empty() {
+            break;
+        }
+
+        all_categories.extend(page_items);
+        page += 1;
+    }
+
+    Ok(all_categories)
+}
+
+async fn fetch_all_tags(
+    base_url: &str,
+    username: &str,
+    password: &str,
+) -> Result<Vec<WordPressTag>, Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let mut all_tags: Vec<WordPressTag> = Vec::new();
+    let mut page: u32 = 1;
+
+    loop {
+        let url = format!("{}/wp-json/wp/v2/tags", base_url);
+        let response = client
+            .get(&url)
+            .basic_auth(username, Some(password))
+            .query(&[("per_page", "100"), ("page", &page.to_string())])
+            .send()
+            .await?;
+
+        if response.status() == StatusCode::BAD_REQUEST && page > 1 {
+            break;
+        }
+
+        if !response.status().is_success() {
+            return Err(io::Error::other(format!(
+                "タグ一覧の取得に失敗しました (status: {})",
+                response.status()
+            ))
+            .into());
+        }
+
+        let page_items: Vec<WordPressTag> = response.json().await?;
+        if page_items.is_empty() {
+            break;
+        }
+
+        all_tags.extend(page_items);
+        page += 1;
+    }
+
+    Ok(all_tags)
 }
 
 /// サンプルの固定ページ: (タイトル, 本文HTML)

--- a/examples/wordpress_site_builder_demo.rs
+++ b/examples/wordpress_site_builder_demo.rs
@@ -70,9 +70,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     // 環境変数から認証情報を取得
-    let wp_url = env::var("WORDPRESS_URL").unwrap_or_else(|_| {
-        "https://your-site.example.com/wp-json".to_string()
-    });
+    let wp_url = env::var("WORDPRESS_URL")
+        .unwrap_or_else(|_| "https://your-site.example.com/wp-json".to_string());
     let wp_username = env::var("WORDPRESS_USERNAME").unwrap_or_default();
     let wp_password = env::var("WORDPRESS_PASSWORD").unwrap_or_default();
 

--- a/examples/wordpress_site_builder_demo.rs
+++ b/examples/wordpress_site_builder_demo.rs
@@ -31,6 +31,7 @@ use mcp_rs::{
 };
 use std::collections::HashSet;
 use std::env;
+use std::io::{self, Write};
 use tokio::time::{sleep, Duration};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -107,10 +108,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         rate_limit: None,
         encrypted_credentials: None,
     })
-    .map_err(|e| format!("WordPress ハンドラーの初期化に失敗しました: {}", e))?;
+    .map_err(|e| io::Error::other(format!("WordPress ハンドラーの初期化に失敗しました: {}", e)))?;
 
     // ── Step 1: ヘルスチェック ──────────────────────────────────────────────
     print!("[1/6] 🔍 WordPress 接続確認... ");
+    io::stdout().flush()?;
     let health = handler.health_check().await;
     if health.error_details.is_empty() {
         let site_name = health
@@ -130,6 +132,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Step 2: サイト設定 ──────────────────────────────────────────────────
     print!("[2/6] ⚙️  サイト基本設定を更新中... ");
+    io::stdout().flush()?;
     handler
         .update_settings(SettingsUpdateParams {
             title: Some(SITE_TITLE.to_string()),
@@ -266,8 +269,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await
         {
             Ok(page) => {
-                println!("   ✅ 「{}」(ID: {})", title, page.id.unwrap_or(0));
-                existing_page_titles.insert(normalize_title(&title));
+                if let Some(page_id) = page.id {
+                    println!("   ✅ 「{}」(ID: {})", title, page_id);
+                    existing_page_titles.insert(normalize_title(&title));
+                } else {
+                    warning_count += 1;
+                    println!("   ⚠️  「{}」作成成功だがIDが取得できませんでした", title);
+                }
             }
             Err(e) => {
                 warning_count += 1;
@@ -321,8 +329,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await
         {
             Ok(post) => {
-                println!("   ✅ 「{}」(ID: {})", title, post.id.unwrap_or(0));
-                existing_post_titles.insert(normalize_title(&title));
+                if let Some(post_id) = post.id {
+                    println!("   ✅ 「{}」(ID: {})", title, post_id);
+                    existing_post_titles.insert(normalize_title(&title));
+                } else {
+                    warning_count += 1;
+                    println!("   ⚠️  「{}」作成成功だがIDが取得できませんでした", title);
+                }
             }
             Err(e) => {
                 warning_count += 1;

--- a/examples/wordpress_site_builder_demo.rs
+++ b/examples/wordpress_site_builder_demo.rs
@@ -1,0 +1,297 @@
+//! WordPress Site Builder Demo
+//!
+//! mcp-rs を使って WordPress サイトの初期構成を一括構築するデモ。
+//! カテゴリ・タグ・固定ページ・ブログ記事をコードから自動生成する。
+//!
+//! ## 実行方法
+//! ```bash
+//! export WORDPRESS_URL="https://your-site.example.com/wp-json"
+//! export WORDPRESS_USERNAME="your_username"
+//! export WORDPRESS_PASSWORD="your_app_password"
+//!
+//! cargo run --example wordpress_site_builder_demo
+//! ```
+//!
+//! アプリケーションパスワードの取得:
+//!   WordPress 管理画面 → ユーザー → プロフィール → アプリケーションパスワード
+//!
+//! ## 構築ステップ
+//! 1. WordPress 接続確認（ヘルスチェック）
+//! 2. サイト基本設定（タイトル・説明・タイムゾーン）
+//! 3. カテゴリ作成
+//! 4. タグ作成
+//! 5. 固定ページ作成
+//! 6. ブログ記事作成
+
+use mcp_rs::{
+    config::WordPressConfig,
+    handlers::wordpress::{PostCreateParams, SettingsUpdateParams, WordPressHandler},
+};
+use std::env;
+use tokio::time::{sleep, Duration};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// サイト固有の設定 — ここを編集してください
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SITE_TITLE: &str = "My Project Site";
+const SITE_DESCRIPTION: &str = "A project site built with mcp-rs";
+const SITE_TIMEZONE: &str = "Asia/Tokyo";
+const SITE_LANGUAGE: &str = "ja";
+
+/// 作成するカテゴリ一覧: (名前, 説明)
+const CATEGORIES: &[(&str, &str)] = &[
+    ("お知らせ", "リリース・更新情報"),
+    ("技術ブログ", "技術的な解説・知見"),
+    ("使い方", "機能説明・チュートリアル"),
+    ("開発ログ", "開発進捗・振り返り"),
+];
+
+/// 作成するタグ一覧: (名前, 説明)
+const TAGS: &[(&str, &str)] = &[
+    ("Rust", "Rust プログラミング言語"),
+    ("オープンソース", "オープンソース開発"),
+    ("チュートリアル", "入門・手順解説"),
+    ("リリース", "バージョンアップ情報"),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("warn")
+        .with_target(false)
+        .init();
+
+    println!("╔══════════════════════════════════════════════════════╗");
+    println!("║     WordPress Site Builder — Powered by mcp-rs       ║");
+    println!("╚══════════════════════════════════════════════════════╝");
+    println!();
+
+    // 環境変数から認証情報を取得
+    let wp_url = env::var("WORDPRESS_URL").unwrap_or_else(|_| {
+        "https://your-site.example.com/wp-json".to_string()
+    });
+    let wp_username = env::var("WORDPRESS_USERNAME").unwrap_or_default();
+    let wp_password = env::var("WORDPRESS_PASSWORD").unwrap_or_default();
+
+    if wp_username.is_empty() || wp_password.is_empty() {
+        eprintln!("❌ 環境変数を設定してください:");
+        eprintln!("   export WORDPRESS_URL='https://your-site.example.com/wp-json'");
+        eprintln!("   export WORDPRESS_USERNAME='your_username'");
+        eprintln!("   export WORDPRESS_PASSWORD='your_app_password'");
+        std::process::exit(1);
+    }
+
+    println!("📡 接続先: {}", wp_url);
+    println!("👤 ユーザー: {}", wp_username);
+    println!();
+
+    let handler = WordPressHandler::new(WordPressConfig {
+        url: wp_url,
+        username: wp_username,
+        password: wp_password,
+        enabled: Some(true),
+        timeout_seconds: Some(30),
+        rate_limit: None,
+        encrypted_credentials: None,
+    });
+
+    // ── Step 1: ヘルスチェック ──────────────────────────────────────────────
+    print!("[1/6] 🔍 WordPress 接続確認... ");
+    let health = handler.health_check().await;
+    if health.error_details.is_empty() {
+        let site_name = health
+            .site_info
+            .as_ref()
+            .map(|s| s.name.as_str())
+            .unwrap_or("—");
+        println!("✅ 接続成功 (サイト名: {})", site_name);
+    } else {
+        println!("⚠️  警告あり");
+        for err in &health.error_details {
+            eprintln!("     {}", err);
+        }
+    }
+
+    // ── Step 2: サイト設定 ──────────────────────────────────────────────────
+    print!("[2/6] ⚙️  サイト基本設定を更新中... ");
+    handler
+        .update_settings(SettingsUpdateParams {
+            title: Some(SITE_TITLE.to_string()),
+            description: Some(SITE_DESCRIPTION.to_string()),
+            timezone: Some(SITE_TIMEZONE.to_string()),
+            show_on_front: None,
+            page_on_front: None,
+            page_for_posts: None,
+            posts_per_page: None,
+            default_category: None,
+            language: Some(SITE_LANGUAGE.to_string()),
+        })
+        .await?;
+    println!("✅");
+    sleep(Duration::from_millis(300)).await;
+
+    // ── Step 3: カテゴリ作成 ────────────────────────────────────────────────
+    println!("[3/6] 🏷️  カテゴリを作成中...");
+    let mut category_ids: Vec<(String, u64)> = Vec::new();
+    for (name, desc) in CATEGORIES {
+        match handler.create_category(name, Some(desc), None).await {
+            Ok(cat) => {
+                let id = cat.id.unwrap_or(0);
+                println!("   ✅ 「{}」(ID: {})", name, id);
+                category_ids.push((name.to_string(), id));
+            }
+            Err(e) => {
+                println!("   ⚠️  「{}」スキップ（既存の可能性）: {}", name, e);
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    // ── Step 4: タグ作成 ────────────────────────────────────────────────────
+    println!("[4/6] 🔖 タグを作成中...");
+    let mut tag_ids: Vec<(String, u64)> = Vec::new();
+    for (name, desc) in TAGS {
+        match handler.create_tag(name, Some(desc)).await {
+            Ok(tag) => {
+                let id = tag.id.unwrap_or(0);
+                println!("   ✅ 「{}」(ID: {})", name, id);
+                tag_ids.push((name.to_string(), id));
+            }
+            Err(e) => {
+                println!("   ⚠️  「{}」スキップ: {}", name, e);
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    // ── Step 5: 固定ページ作成 ──────────────────────────────────────────────
+    println!("[5/6] 📄 固定ページを作成中...");
+    for (title, content) in sample_pages() {
+        match handler
+            .create_advanced_post(PostCreateParams {
+                title: title.clone(),
+                content,
+                post_type: "page".to_string(),
+                status: "publish".to_string(),
+                date: None,
+                categories: None,
+                tags: None,
+                featured_media_id: None,
+                meta: None,
+            })
+            .await
+        {
+            Ok(page) => println!("   ✅ 「{}」(ID: {})", title, page.id.unwrap_or(0)),
+            Err(e) => println!("   ⚠️  「{}」スキップ: {}", title, e),
+        }
+        sleep(Duration::from_millis(400)).await;
+    }
+
+    // ── Step 6: ブログ記事作成 ──────────────────────────────────────────────
+    println!("[6/6] ✍️  ブログ記事を作成中...");
+
+    let find_cat = |name: &str| -> u64 {
+        category_ids
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, id)| *id)
+            .unwrap_or(1)
+    };
+    let find_tag = |name: &str| -> u64 {
+        tag_ids
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, id)| *id)
+            .unwrap_or(0)
+    };
+
+    for (title, content, cats, tags) in sample_posts(&find_cat, &find_tag) {
+        match handler
+            .create_advanced_post(PostCreateParams {
+                title: title.clone(),
+                content,
+                post_type: "post".to_string(),
+                status: "publish".to_string(),
+                date: None,
+                categories: Some(cats),
+                tags: Some(tags),
+                featured_media_id: None,
+                meta: None,
+            })
+            .await
+        {
+            Ok(post) => println!("   ✅ 「{}」(ID: {})", title, post.id.unwrap_or(0)),
+            Err(e) => println!("   ⚠️  「{}」スキップ: {}", title, e),
+        }
+        sleep(Duration::from_millis(400)).await;
+    }
+
+    println!();
+    println!("╔══════════════════════════════════════════════════════╗");
+    println!("║  🎉 サイト初期構築完了！                              ║");
+    println!("╚══════════════════════════════════════════════════════╝");
+
+    Ok(())
+}
+
+/// サンプルの固定ページ: (タイトル, 本文HTML)
+///
+/// 実際のプロジェクトに合わせて内容を差し替えてください。
+fn sample_pages() -> Vec<(String, String)> {
+    vec![
+        (
+            "About".to_string(),
+            r#"<!-- wp:paragraph -->
+<p>このサイトについての説明をここに記載します。</p>
+<!-- /wp:paragraph -->"#
+                .to_string(),
+        ),
+        (
+            "Contact".to_string(),
+            r#"<!-- wp:paragraph -->
+<p>お問い合わせ方法についての説明をここに記載します。</p>
+<!-- /wp:paragraph -->"#
+                .to_string(),
+        ),
+    ]
+}
+
+/// サンプルのブログ記事: (タイトル, 本文HTML, カテゴリID一覧, タグID一覧)
+///
+/// 実際のプロジェクトに合わせて内容を差し替えてください。
+fn sample_posts<F, G>(find_cat: &F, find_tag: &G) -> Vec<(String, String, Vec<u64>, Vec<u64>)>
+where
+    F: Fn(&str) -> u64,
+    G: Fn(&str) -> u64,
+{
+    vec![
+        (
+            "サイトをオープンしました".to_string(),
+            r#"<!-- wp:paragraph -->
+<p>ようこそ。このサイトは <a href="https://github.com/rireki-ai/mcp-rs">mcp-rs</a> を使って自動構築されました。</p>
+<!-- /wp:paragraph -->"#
+                .to_string(),
+            vec![find_cat("お知らせ")],
+            vec![find_tag("リリース"), find_tag("オープンソース")],
+        ),
+        (
+            "mcp-rs で WordPress を自動構築する方法".to_string(),
+            r#"<!-- wp:paragraph -->
+<p>mcp-rs の WordPress ツール群を使うと、カテゴリ・タグ・ページ・記事をコードから一括生成できます。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:code -->
+<pre class="wp-block-code"><code class="language-bash">export WORDPRESS_URL="https://your-site.example.com/wp-json"
+export WORDPRESS_USERNAME="your_username"
+export WORDPRESS_PASSWORD="your_app_password"
+cargo run --example wordpress_site_builder_demo</code></pre>
+<!-- /wp:code -->"#
+                .to_string(),
+            vec![find_cat("技術ブログ")],
+            vec![find_tag("Rust"), find_tag("チュートリアル")],
+        ),
+    ]
+}

--- a/examples/wordpress_site_builder_demo.rs
+++ b/examples/wordpress_site_builder_demo.rs
@@ -5,12 +5,14 @@
 //!
 //! ## 実行方法
 //! ```bash
-//! export WORDPRESS_URL="https://your-site.example.com/wp-json"
+//! export WORDPRESS_URL="https://your-site.example.com"
 //! export WORDPRESS_USERNAME="your_username"
 //! export WORDPRESS_PASSWORD="your_app_password"
 //!
 //! cargo run --example wordpress_site_builder_demo
 //! ```
+//!
+//! `WORDPRESS_URL` には `/wp-json` を含めず、サイトのベース URL を指定してください。
 //!
 //! アプリケーションパスワードの取得:
 //!   WordPress 管理画面 → ユーザー → プロフィール → アプリケーションパスワード
@@ -70,14 +72,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     // 環境変数から認証情報を取得
-    let wp_url = env::var("WORDPRESS_URL")
-        .unwrap_or_else(|_| "https://your-site.example.com/wp-json".to_string());
+    let wp_url =
+        env::var("WORDPRESS_URL").unwrap_or_else(|_| "https://your-site.example.com".to_string());
     let wp_username = env::var("WORDPRESS_USERNAME").unwrap_or_default();
     let wp_password = env::var("WORDPRESS_PASSWORD").unwrap_or_default();
 
     if wp_username.is_empty() || wp_password.is_empty() {
         eprintln!("❌ 環境変数を設定してください:");
-        eprintln!("   export WORDPRESS_URL='https://your-site.example.com/wp-json'");
+        eprintln!("   export WORDPRESS_URL='https://your-site.example.com'");
         eprintln!("   export WORDPRESS_USERNAME='your_username'");
         eprintln!("   export WORDPRESS_PASSWORD='your_app_password'");
         std::process::exit(1);
@@ -138,9 +140,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for (name, desc) in CATEGORIES {
         match handler.create_category(name, Some(desc), None).await {
             Ok(cat) => {
-                let id = cat.id.unwrap_or(0);
-                println!("   ✅ 「{}」(ID: {})", name, id);
-                category_ids.push((name.to_string(), id));
+                if let Some(id) = cat.id {
+                    println!("   ✅ 「{}」(ID: {})", name, id);
+                    category_ids.push((name.to_string(), id));
+                } else {
+                    println!("   ⚠️  「{}」スキップ（IDが取得できませんでした）", name);
+                }
             }
             Err(e) => {
                 println!("   ⚠️  「{}」スキップ（既存の可能性）: {}", name, e);
@@ -155,9 +160,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for (name, desc) in TAGS {
         match handler.create_tag(name, Some(desc)).await {
             Ok(tag) => {
-                let id = tag.id.unwrap_or(0);
-                println!("   ✅ 「{}」(ID: {})", name, id);
-                tag_ids.push((name.to_string(), id));
+                if let Some(id) = tag.id {
+                    println!("   ✅ 「{}」(ID: {})", name, id);
+                    tag_ids.push((name.to_string(), id));
+                } else {
+                    println!("   ⚠️  「{}」スキップ（IDが取得できませんでした）", name);
+                }
             }
             Err(e) => {
                 println!("   ⚠️  「{}」スキップ: {}", name, e);
@@ -192,20 +200,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // ── Step 6: ブログ記事作成 ──────────────────────────────────────────────
     println!("[6/6] ✍️  ブログ記事を作成中...");
 
-    let find_cat = |name: &str| -> u64 {
+    let find_cat = |name: &str| -> Option<u64> {
         category_ids
             .iter()
             .find(|(n, _)| n == name)
             .map(|(_, id)| *id)
-            .unwrap_or(1)
     };
-    let find_tag = |name: &str| -> u64 {
-        tag_ids
-            .iter()
-            .find(|(n, _)| n == name)
-            .map(|(_, id)| *id)
-            .unwrap_or(0)
-    };
+    let find_tag =
+        |name: &str| -> Option<u64> { tag_ids.iter().find(|(n, _)| n == name).map(|(_, id)| *id) };
 
     for (title, content, cats, tags) in sample_posts(&find_cat, &find_tag) {
         match handler
@@ -263,8 +265,8 @@ fn sample_pages() -> Vec<(String, String)> {
 /// 実際のプロジェクトに合わせて内容を差し替えてください。
 fn sample_posts<F, G>(find_cat: &F, find_tag: &G) -> Vec<(String, String, Vec<u64>, Vec<u64>)>
 where
-    F: Fn(&str) -> u64,
-    G: Fn(&str) -> u64,
+    F: Fn(&str) -> Option<u64>,
+    G: Fn(&str) -> Option<u64>,
 {
     vec![
         (
@@ -273,8 +275,14 @@ where
 <p>ようこそ。このサイトは <a href="https://github.com/rireki-ai/mcp-rs">mcp-rs</a> を使って自動構築されました。</p>
 <!-- /wp:paragraph -->"#
                 .to_string(),
-            vec![find_cat("お知らせ")],
-            vec![find_tag("リリース"), find_tag("オープンソース")],
+            vec![find_cat("お知らせ")]
+                .into_iter()
+                .flatten()
+                .collect(),
+            vec![find_tag("リリース"), find_tag("オープンソース")]
+                .into_iter()
+                .flatten()
+                .collect(),
         ),
         (
             "mcp-rs で WordPress を自動構築する方法".to_string(),
@@ -283,14 +291,20 @@ where
 <!-- /wp:paragraph -->
 
 <!-- wp:code -->
-<pre class="wp-block-code"><code class="language-bash">export WORDPRESS_URL="https://your-site.example.com/wp-json"
+<pre class="wp-block-code"><code class="language-bash">export WORDPRESS_URL="https://your-site.example.com"
 export WORDPRESS_USERNAME="your_username"
 export WORDPRESS_PASSWORD="your_app_password"
 cargo run --example wordpress_site_builder_demo</code></pre>
 <!-- /wp:code -->"#
                 .to_string(),
-            vec![find_cat("技術ブログ")],
-            vec![find_tag("Rust"), find_tag("チュートリアル")],
+            vec![find_cat("技術ブログ")]
+                .into_iter()
+                .flatten()
+                .collect(),
+            vec![find_tag("Rust"), find_tag("チュートリアル")]
+                .into_iter()
+                .flatten()
+                .collect(),
         ),
     ]
 }

--- a/src/policy_watcher.rs
+++ b/src/policy_watcher.rs
@@ -254,8 +254,7 @@ mod tests {
         // テスト完了後、監視タスクを強制終了
         watcher_task.abort();
 
-        if result.is_ok() {
-            let event = result.unwrap().unwrap();
+        if let Ok(Ok(event)) = result {
             assert!(event.file_path.contains("test_policy.toml"));
             assert!(matches!(
                 event.change_type,

--- a/tests/ai_error_handling_test.rs
+++ b/tests/ai_error_handling_test.rs
@@ -155,7 +155,7 @@ fn test_builder_pattern_chaining() {
 
 #[test]
 fn test_multiple_chat_roles() {
-    let messages = vec![
+    let messages = [
         ChatMessage::system("System prompt"),
         ChatMessage::user("User message 1"),
         ChatMessage::assistant("Assistant response 1"),

--- a/tests/database/mysql_phase1_tests.rs
+++ b/tests/database/mysql_phase1_tests.rs
@@ -254,7 +254,7 @@ fn test_complex_parameterized_query_validation() {
     let param_count = complex_sql.matches('?').count();
     assert_eq!(param_count, 7);
 
-    let params = vec![
+    let params = [
         Value::Int(123),
         Value::Bool(true),
         Value::DateTime(Utc::now()),

--- a/tests/threat_intelligence/mitre_attack_provider_tests.rs
+++ b/tests/threat_intelligence/mitre_attack_provider_tests.rs
@@ -209,8 +209,7 @@ mod integration_tests {
         let result = provider.check_indicator(&indicator).await;
 
         // APIが利用できない場合はスキップ
-        if result.is_ok() {
-            let threats = result.unwrap();
+        if let Ok(threats) = result {
             assert!(!threats.is_empty());
 
             let threat = &threats[0];
@@ -226,8 +225,7 @@ mod integration_tests {
 
         let result = provider.health_check().await;
 
-        if result.is_ok() {
-            let health = result.unwrap();
+        if let Ok(health) = result {
             assert_eq!(health.provider_name, "MITRE-ATTACK");
         }
     }
@@ -249,8 +247,7 @@ mod integration_tests {
 
         let result = provider.check_indicator(&indicator).await;
 
-        if result.is_ok() {
-            let threats = result.unwrap();
+        if let Ok(threats) = result {
             // キーワード検索の結果は空の場合もある
             println!("Found {} threats for keyword 'phishing'", threats.len());
         }
@@ -283,8 +280,7 @@ mod integration_tests {
 
         let result = provider.batch_check_indicators(&indicators).await;
 
-        if result.is_ok() {
-            let threats = result.unwrap();
+        if let Ok(threats) = result {
             println!("Batch check found {} threats", threats.len());
         }
     }


### PR DESCRIPTION
## 概要

Close #266

mcp-rs の WordPress ツール群（27ツール）を使ったサイト初期構築デモを `examples/` に追加する。

## 変更内容

### 追加ファイル

- `examples/wordpress_site_builder_demo.rs` — WordPress サイト一括構築デモ

### 構築ステップ（6段階）

1. WordPress 接続確認（ヘルスチェック）
2. サイト基本設定（タイトル・説明・タイムゾーン）
3. カテゴリ一括作成
4. タグ一括作成
5. 固定ページ作成
6. ブログ記事作成

### 使用する mcp-rs API

- `WordPressHandler::try_new` — パニックしない初期化
- `WordPressHandler::health_check`
- `WordPressHandler::update_settings`（`SettingsUpdateParams`）
- `WordPressHandler::create_category` / `get_categories`
- `WordPressHandler::create_tag` / `get_tags`
- `WordPressHandler::create_advanced_post`（`PostCreateParams`）

### 依存更新・セキュリティ対応（同ブランチに含む）

| 対応 | 詳細 |
|---|---|
| `hickory-resolver` 0.24.4 → 0.26.1 | RUSTSEC-2026-0119 (CPU 枯渇) を解消 |
| `mongodb` 3.1 → 3.6 | 最新版に更新 |
| RUSTSEC-2026-0118 を ignore | 修正バージョンなし・mcp-rs では DNSSEC 検証を行わないため実害なし |
| RUSTSEC-2026-0119 を ignore | mongodb 3.6.0 が内部で hickory-proto 0.25.2 を固定しており制御不能 |

## 設計方針

- **特定サービスへの依存なし** — URL・コンテンツはプレースホルダー
- `CATEGORIES` / `TAGS` / `sample_pages()` / `sample_posts()` を差し替えるだけで任意サイトに適用可能
- 環境変数（`WORDPRESS_URL`, `WORDPRESS_USERNAME`, `WORDPRESS_PASSWORD`）で認証情報を注入
- カテゴリ/タグが既存の場合は一覧から名前でID解決して後続処理を継続

## 実行方法

```bash
export WORDPRESS_URL="https://your-site.example.com"
export WORDPRESS_USERNAME="your_username"
export WORDPRESS_PASSWORD="your_app_password"

cargo run --example wordpress_site_builder_demo
```

> `WORDPRESS_URL` には `/wp-json` を含めず、サイトのベース URL を指定してください。

## 動作確認

- `cargo build --example wordpress_site_builder_demo` ビルド成功を確認済み
- `cargo clippy --example wordpress_site_builder_demo -- -D warnings` 警告なし
- `cargo audit` — 脆弱性 0 件（3件は ignore 済み）
