### PR TITLE
Document redring.jp demo site and refine WordPress posts

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -54,4 +54,17 @@ ignore = [
     #               is not exposed externally; track mongodb release with updated hickory
     "RUSTSEC-2026-0119",
 
+    # RUSTSEC-2026-0173: proc-macro-error2 is unmaintained
+    # - Affects: proc-macro-error2 2.0.1 (via validator, mysql_async transitive)
+    # - Status: Unmaintained but no critical functionality loss
+    # - Mitigation: validator and mysql_async are stable; proc-macro-error2 only used for derive macro code gen
+    "RUSTSEC-2026-0173",
+
+    # RUSTSEC-2026-0097: Rand is unsound with a custom logger using `rand::rng()`
+    # - Affects: rand 0.8.5, 0.9.2 (transitive via redis, tokio-retry, sqlx, smartcore, tungstenite, etc.)
+    # - Status: Design flaw; requires custom logger + rand::rng() to trigger (not default usage)
+    # - Mitigation: mcp-rs does not use rand::rng() with custom logger; default usage is safe
+    #               Upgrading rand across entire ecosystem is infeasible due to multiple major consumers
+    "RUSTSEC-2026-0097",
+
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ clippy-report.json
 .env
 .env.local
 .env.production
+.env.wordpress.local
 
 # Release directories (should use GitHub Releases instead)
 /mcp-rs-v*/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -538,7 +538,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -548,6 +548,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -800,7 +809,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -853,6 +862,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -908,6 +923,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1163,6 +1184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,7 +1242,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1317,7 +1356,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1428,10 +1467,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1500,7 +1551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1526,7 +1577,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1560,7 +1611,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1661,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1999,7 +2050,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2324,7 +2375,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2333,7 +2384,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2411,6 +2471,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2520,7 +2589,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2792,7 +2861,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2964,7 +3033,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.16",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -2972,7 +3041,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -3167,13 +3236,14 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall",
+ "plain",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -3413,7 +3483,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2",
+ "sha2 0.10.9",
  "smartcore",
  "sqlx",
  "statrs",
@@ -3453,7 +3523,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3512,7 +3592,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -3524,7 +3604,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -3607,9 +3687,9 @@ dependencies = [
  "hex",
  "hickory-proto 0.25.2",
  "hickory-resolver 0.25.2",
- "hmac",
+ "hmac 0.12.1",
  "macro_magic",
- "md-5",
+ "md-5 0.10.6",
  "mongocrypt",
  "mongodb-internal-macros",
  "pbkdf2",
@@ -3622,7 +3702,7 @@ dependencies = [
  "serde_bytes",
  "serde_with",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "socket2 0.6.1",
  "stringprep",
  "strsim",
@@ -3726,7 +3806,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.17",
  "uuid",
 ]
@@ -4066,7 +4146,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4078,7 +4158,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4105,7 +4185,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -4139,8 +4219,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4208,7 +4288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf1d70880e76bdc13ba52eafa6239ce793d85c8e43896507e43dd8984ff05b82"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4342,6 +4422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,27 +4508,27 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.9"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbef655056b916eb868048276cfd5d6a7dea4f81560dfd047f97c8c6fe3fcfd4"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
- "md-5",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
  "memchr",
- "rand 0.9.2",
- "sha2",
+ "rand 0.10.1",
+ "sha2 0.11.0",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4605b7c057056dd35baeb6ac0c0338e4975b1f2bef0f65da953285eb007095"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
@@ -4659,7 +4745,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -4677,7 +4763,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4686,9 +4772,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -4714,7 +4800,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4916,6 +5002,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5035,7 +5130,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -5073,8 +5168,8 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -5147,7 +5242,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5592,7 +5687,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5609,7 +5704,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5663,7 +5769,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5824,7 +5930,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.17",
  "tokio",
@@ -5863,7 +5969,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -5886,7 +5992,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -5896,10 +6002,10 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
@@ -5907,14 +6013,14 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.17",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -5936,24 +6042,24 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
  "thiserror 2.0.17",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -6128,7 +6234,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6337,9 +6443,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b40d66d9b2cfe04b628173409368e58247e8eddbbd3b0e6c6ba1d09f20f6c9e"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6354,11 +6460,11 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.10.1",
  "socket2 0.6.1",
  "tokio",
  "tokio-util",
- "whoami",
+ "whoami 2.1.0",
 ]
 
 [[package]]
@@ -6494,11 +6600,11 @@ checksum = "f124352108f58ef88299e909f6e9470f1cdc8d2a1397963901b4a6366206bf72"
 dependencies = [
  "base32",
  "constant_time_eq",
- "hmac",
+ "hmac 0.12.1",
  "qrcodegen-image",
  "rand 0.9.2",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "url",
  "urlencoding",
 ]
@@ -6698,9 +6804,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -6759,7 +6865,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -6897,6 +7003,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6919,6 +7034,15 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -7082,7 +7206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
- "wasite",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
+dependencies = [
+ "libredox",
+ "wasite 1.0.2",
  "web-sys",
 ]
 
@@ -7124,7 +7258,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2589,7 +2589,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2861,7 +2861,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3297,11 +3297,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.14.0"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3758,9 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_async"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277ce2f2459b2af4cc6d0a0b7892381f80800832f57c533f03e2845f4ea331ea"
+checksum = "d1d9585dc9058886ff3a1f48a23024dd1d054264dee7c5ae0e4bd640c953bee5"
 dependencies = [
  "bytes",
  "crossbeam-queue",
@@ -4763,7 +4763,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4800,7 +4800,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5242,7 +5242,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6234,7 +6234,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7258,7 +7258,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,6 +55,10 @@ WordPress セキュリティ自動化が必要ですか？SQL インジェクシ
 - **YouTube・ソーシャル埋め込み**: セキュリティ検証付きリッチメディア統合
 - **ユーザー管理**: ロールベースアクセス制御とユーザー操作
 
+### ライブデモサイト
+
+`examples/wordpress_site_builder_demo.rs` の例は、公開 WordPress デモサイト [redring.jp](https://redring.jp/) を構築・更新します。mcp-rs がサイトを立ち上げ、コンテンツを整理し、[トップページ構成案を反映しました](https://redring.jp/homepage-structure-update/) のような実運用記事とつながることを示す実例です。
+
 ## **エンタープライズセキュリティ（6 層アーキテクチャ）**
 
 - **AES-GCM-256 暗号化**: PBKDF2 鍵導出による軍用グレード暗号化

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Need WordPress security automation? 8-layer enterprise security architecture wit
 - **YouTube & Social Embeds**: Rich media integration with security validation
 - **User Management**: Role-based access control and user operations
 
+### Live Demo Site
+
+The `examples/wordpress_site_builder_demo.rs` example builds and updates the public WordPress demo site at [redring.jp](https://redring.jp/). It is a real-world showcase of how mcp-rs can bootstrap a site, organize content, and keep the structure aligned with the demo article on [トップページ構成案を反映しました](https://redring.jp/homepage-structure-update/).
+
 ## **Multi-Factor Authentication (MFA)**
 
 - **TOTP Authentication**: RFC 6238 compliant with QR code generation (SHA1/SHA256/SHA512)

--- a/examples/wordpress_site_builder_demo.rs
+++ b/examples/wordpress_site_builder_demo.rs
@@ -1,7 +1,9 @@
 //! WordPress Site Builder Demo
 //!
 //! mcp-rs を使って WordPress サイトの初期構成を一括構築するデモ。
-//! カテゴリ・タグ・固定ページ・ブログ記事をコードから自動生成する。
+//! カテゴリ・タグ・固定ページ・メニュー・ブログ記事をコードから自動生成する。
+//! 実行は WordPress REST API とアプリケーションパスワードを利用する。
+//! wp-admin のログイン操作や reCAPTCHA 自動化には依存しない。
 //!
 //! ## 実行方法
 //! ```bash
@@ -23,8 +25,11 @@
 //! 3. カテゴリ作成
 //! 4. タグ作成
 //! 5. 固定ページ作成
-//! 6. ブログ記事作成
+//! 6. メニュー作成
+//! 7. ブログ記事作成
 
+use crossterm::event::{read, Event, KeyCode, KeyEventKind};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use mcp_rs::{
     config::WordPressConfig,
     handlers::wordpress::{
@@ -32,37 +37,62 @@ use mcp_rs::{
     },
 };
 use reqwest::{Client, StatusCode};
-use std::collections::HashSet;
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
 use std::env;
+use std::fs;
 use std::io::{self, Write};
 use tokio::time::{sleep, Duration};
 
-// ─────────────────────────────────────────────────────────────────────────────
-// サイト固有の設定 — ここを編集してください
-// ─────────────────────────────────────────────────────────────────────────────
+// -----------------------------------------------------------------------------
+// サイト固有の設定
+// -----------------------------------------------------------------------------
 
-const SITE_TITLE: &str = "My Project Site";
-const SITE_DESCRIPTION: &str = "A project site built with mcp-rs";
+const SITE_TITLE: &str = "redring.jp";
+const SITE_DESCRIPTION: &str = "3DCAD・幾何処理・設計自動化を軸に発信する RedRing の公式サイト";
 const SITE_TIMEZONE: &str = "Asia/Tokyo";
 const SITE_LANGUAGE: &str = "ja";
+const FRONT_PAGE_TITLE: &str = "ホーム";
+const SITE_GUIDE_TITLE: &str = "サイトガイド";
+const POSTS_PAGE_TITLE: &str = "投稿一覧";
+const ABOUT_US_TITLE: &str = "About Us";
+const CONTRIBUTORS_TITLE: &str = "Contributors募集";
+const PRIMARY_MENU_NAME: &str = "Primary Navigation";
+const FOOTER_MENU_NAME: &str = "Footer Navigation";
+const WORDPRESS_LOCAL_ENV_FILE: &str = ".env.wordpress.local";
 
-/// 作成するカテゴリ一覧: (名前, 説明)
 const CATEGORIES: &[(&str, &str)] = &[
+    ("ウェブサイト", "サイト運用・導線設計・UI改善"),
     ("お知らせ", "リリース・更新情報"),
-    ("技術ブログ", "技術的な解説・知見"),
-    ("使い方", "機能説明・チュートリアル"),
-    ("開発ログ", "開発進捗・振り返り"),
+    ("RedRing思想", "思想・設計哲学"),
+    ("構造設計", "構造美と設計原則"),
+    ("技術信頼性", "品質・安全性・運用性"),
+    ("実装記録", "実装手順・検証ログ"),
 ];
 
-/// 作成するタグ一覧: (名前, 説明)
 const TAGS: &[(&str, &str)] = &[
+    ("サイト運用", "サイト全体の運用・保守・改善"),
+    ("UI改善", "見た目と操作性の改善"),
+    ("導線整理", "情報の流れと回遊性の改善"),
+    ("RedRing", "RedRing プロジェクト関連"),
+    ("mcp-rs", "mcp-rs 実装関連"),
+    ("MCP", "Model Context Protocol"),
     ("Rust", "Rust プログラミング言語"),
-    ("オープンソース", "オープンソース開発"),
-    ("チュートリアル", "入門・手順解説"),
-    ("リリース", "バージョンアップ情報"),
+    ("WordPress", "WordPress 連携"),
+    ("セキュリティ", "セキュリティ関連"),
+    ("監査ログ", "変更履歴と操作証跡の記録"),
+    ("監視", "異常検知と状態監視"),
+    ("生成AI", "AI 活用・実装"),
+    ("運用自動化", "運用効率化と自動化"),
+    ("構造美", "情報設計と視覚的構造"),
+    ("GitHub", "開発情報への導線"),
 ];
 
-// ─────────────────────────────────────────────────────────────────────────────
+#[derive(Debug, Clone)]
+struct MenuItemSpec {
+    title: String,
+    page_title: String,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -74,27 +104,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("╔══════════════════════════════════════════════════════╗");
     println!("║     WordPress Site Builder — Powered by mcp-rs       ║");
     println!("╚══════════════════════════════════════════════════════╝");
+    println!("REST Mode: WordPress REST API + Application Password");
     println!();
 
-    // 環境変数から認証情報を取得
-    let wp_url_raw =
-        env::var("WORDPRESS_URL").unwrap_or_else(|_| "https://your-site.example.com".to_string());
-    // /wp-json の二重付与を防ぐため、末尾スラッシュと /wp-json を正規化する
+    if let Some(path) = load_local_wordpress_env()? {
+        println!("🔐 ローカル環境ファイルを読み込みました: {}", path);
+    }
+
+    let wp_url_raw = resolve_wp_url()?;
     let wp_url = wp_url_raw
         .trim_end_matches('/')
         .strip_suffix("/wp-json")
         .unwrap_or(wp_url_raw.trim_end_matches('/'))
         .to_string();
-    let wp_username = env::var("WORDPRESS_USERNAME").unwrap_or_default();
-    let wp_password = env::var("WORDPRESS_PASSWORD").unwrap_or_default();
-
-    if wp_username.is_empty() || wp_password.is_empty() {
-        eprintln!("❌ 環境変数を設定してください:");
-        eprintln!("   export WORDPRESS_URL='https://your-site.example.com'");
-        eprintln!("   export WORDPRESS_USERNAME='your_username'");
-        eprintln!("   export WORDPRESS_PASSWORD='your_app_password'");
-        std::process::exit(1);
-    }
+    let wp_username = resolve_wp_username()?;
+    let wp_password = resolve_wp_password()?;
 
     println!("📡 接続先: {}", wp_url);
     println!("👤 ユーザー: {}", wp_username);
@@ -113,8 +137,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     })
     .map_err(|e| io::Error::other(format!("WordPress ハンドラーの初期化に失敗しました: {}", e)))?;
 
-    // ── Step 1: ヘルスチェック ──────────────────────────────────────────────
-    print!("[1/6] 🔍 WordPress 接続確認... ");
+    print!("[1/7] 🔍 WordPress 接続確認... ");
     io::stdout().flush()?;
     let health = handler.health_check().await;
     if health.error_details.is_empty() {
@@ -129,12 +152,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for err in &health.error_details {
             eprintln!("     {}", err);
         }
-        eprintln!("❌ ヘルスチェックで問題が検出されたため、Step 2 以降を中止します。");
-        return Ok(());
+
+        if direct_rest_api_probe(&wp_url).await {
+            println!("   ↪️  直接REST疎通が成功したため、処理を継続します");
+        } else {
+            eprintln!("❌ ヘルスチェックで問題が検出されたため、Step 2 以降を中止します。");
+            return Ok(());
+        }
     }
 
-    // ── Step 2: サイト設定 ──────────────────────────────────────────────────
-    print!("[2/6] ⚙️  サイト基本設定を更新中... ");
+    print!("[2/7] ⚙️  サイト基本設定を更新中... ");
     io::stdout().flush()?;
     handler
         .update_settings(SettingsUpdateParams {
@@ -144,7 +171,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             show_on_front: None,
             page_on_front: None,
             page_for_posts: None,
-            posts_per_page: None,
+            posts_per_page: Some(12),
             default_category: None,
             language: Some(SITE_LANGUAGE.to_string()),
         })
@@ -152,8 +179,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("✅");
     sleep(Duration::from_millis(300)).await;
 
-    // ── Step 3: カテゴリ作成 ────────────────────────────────────────────────
-    println!("[3/6] 🏷️  カテゴリを作成中...");
+    println!("[3/7] 🏷️  カテゴリを作成中...");
     let mut category_ids: Vec<(String, u64)> = Vec::new();
     let existing_categories = fetch_all_categories(&wp_url, &wp_username, &wp_password).await?;
     for (name, desc) in CATEGORIES {
@@ -164,7 +190,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 sleep(Duration::from_millis(200)).await;
                 continue;
             }
-            return Err(std::io::Error::other(format!(
+            return Err(io::Error::other(format!(
                 "カテゴリ「{}」の既存IDが取得できませんでした",
                 name
             ))
@@ -177,7 +203,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("   ✅ 「{}」(ID: {})", name, id);
                     category_ids.push((name.to_string(), id));
                 } else {
-                    return Err(std::io::Error::other(format!(
+                    return Err(io::Error::other(format!(
                         "カテゴリ「{}」の作成後にIDが取得できませんでした",
                         name
                     ))
@@ -185,7 +211,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             Err(e) => {
-                return Err(std::io::Error::other(format!(
+                return Err(io::Error::other(format!(
                     "カテゴリ「{}」の作成に失敗しました: {}",
                     name, e
                 ))
@@ -195,8 +221,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sleep(Duration::from_millis(200)).await;
     }
 
-    // ── Step 4: タグ作成 ────────────────────────────────────────────────────
-    println!("[4/6] 🔖 タグを作成中...");
+    println!("[4/7] 🔖 タグを作成中...");
     let mut tag_ids: Vec<(String, u64)> = Vec::new();
     let existing_tags = fetch_all_tags(&wp_url, &wp_username, &wp_password).await?;
     for (name, desc) in TAGS {
@@ -207,7 +232,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 sleep(Duration::from_millis(200)).await;
                 continue;
             }
-            return Err(std::io::Error::other(format!(
+            return Err(io::Error::other(format!(
                 "タグ「{}」の既存IDが取得できませんでした",
                 name
             ))
@@ -220,7 +245,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("   ✅ 「{}」(ID: {})", name, id);
                     tag_ids.push((name.to_string(), id));
                 } else {
-                    return Err(std::io::Error::other(format!(
+                    return Err(io::Error::other(format!(
                         "タグ「{}」の作成後にIDが取得できませんでした",
                         name
                     ))
@@ -228,7 +253,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
             Err(e) => {
-                return Err(std::io::Error::other(format!(
+                return Err(io::Error::other(format!(
                     "タグ「{}」の作成に失敗しました: {}",
                     name, e
                 ))
@@ -238,21 +263,49 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sleep(Duration::from_millis(200)).await;
     }
 
-    // ── Step 5: 固定ページ作成 ──────────────────────────────────────────────
-    println!("[5/6] 📄 固定ページを作成中...");
+    println!("[5/7] 📄 固定ページを作成中...");
     let (existing_posts, existing_pages) = handler.get_all_content().await?;
-    let mut existing_page_titles: HashSet<String> = existing_pages
-        .iter()
-        .map(|p| normalize_title(&p.title.rendered))
-        .collect();
-    let mut existing_post_titles: HashSet<String> = existing_posts
-        .iter()
-        .map(|p| normalize_title(&p.title.rendered))
-        .collect();
+    let mut page_id_by_title: HashMap<String, u64> = HashMap::new();
+    for page in &existing_pages {
+        if let Some(page_id) = page.id {
+            page_id_by_title.insert(normalize_title(&page.title.rendered), page_id);
+        }
+    }
+    let mut existing_post_ids_by_title: HashMap<String, u64> = HashMap::new();
+    for post in &existing_posts {
+        if let Some(post_id) = post.id {
+            existing_post_ids_by_title.insert(normalize_title(&post.title.rendered), post_id);
+        }
+    }
 
     for (title, content) in sample_pages() {
-        if existing_page_titles.contains(&normalize_title(&title)) {
-            println!("   ♻️  「{}」既存を利用", title);
+        let normalized_title = normalize_title(&title);
+        let existing_page_id = page_id_by_title
+            .get(&normalized_title)
+            .copied()
+            .or_else(|| {
+                legacy_page_title_aliases(&title)
+                    .iter()
+                    .find_map(|legacy| page_id_by_title.get(&normalize_title(legacy)).copied())
+            });
+
+        if let Some(existing_id) = existing_page_id {
+            match update_page_content(
+                &wp_url,
+                &wp_username,
+                &wp_password,
+                existing_id,
+                &title,
+                &content,
+            )
+            .await
+            {
+                Ok(()) => println!("   🔄 「{}」既存ページを更新 (ID: {})", title, existing_id),
+                Err(e) => {
+                    warning_count += 1;
+                    println!("   ⚠️  「{}」更新失敗: {}", title, e);
+                }
+            }
             sleep(Duration::from_millis(200)).await;
             continue;
         }
@@ -260,7 +313,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         match handler
             .create_advanced_post(PostCreateParams {
                 title: title.clone(),
-                content,
+                content: content.clone(),
                 post_type: "page".to_string(),
                 status: "publish".to_string(),
                 date: None,
@@ -273,8 +326,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             Ok(page) => {
                 if let Some(page_id) = page.id {
+                    if let Err(e) = update_page_content(
+                        &wp_url,
+                        &wp_username,
+                        &wp_password,
+                        page_id,
+                        &title,
+                        &content,
+                    )
+                    .await
+                    {
+                        warning_count += 1;
+                        println!("   ⚠️  「{}」作成後のスラッグ更新失敗: {}", title, e);
+                    }
+
                     println!("   ✅ 「{}」(ID: {})", title, page_id);
-                    existing_page_titles.insert(normalize_title(&title));
+                    page_id_by_title.insert(normalized_title, page_id);
                 } else {
                     warning_count += 1;
                     println!("   ⚠️  「{}」作成成功だがIDが取得できませんでした", title);
@@ -288,8 +355,136 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sleep(Duration::from_millis(400)).await;
     }
 
-    // ── Step 6: ブログ記事作成 ──────────────────────────────────────────────
-    println!("[6/6] ✍️  ブログ記事を作成中...");
+    let front_page_id = page_id_by_title
+        .get(&normalize_title(FRONT_PAGE_TITLE))
+        .copied();
+    let posts_page_id = page_id_by_title
+        .get(&normalize_title(POSTS_PAGE_TITLE))
+        .copied();
+
+    if let (Some(front), Some(posts)) = (front_page_id, posts_page_id) {
+        print!("      └─ 🧭 フロントページ設定を適用中... ");
+        io::stdout().flush()?;
+        handler
+            .update_settings(SettingsUpdateParams {
+                title: None,
+                description: None,
+                timezone: None,
+                show_on_front: Some("page".to_string()),
+                page_on_front: Some(front),
+                page_for_posts: Some(posts),
+                posts_per_page: None,
+                default_category: None,
+                language: None,
+            })
+            .await?;
+        println!("✅ (ホームID: {}, 投稿ページID: {})", front, posts);
+    } else {
+        warning_count += 1;
+        println!(
+            "      └─ ⚠️  フロントページ設定をスキップ ({} または {} が見つかりません)",
+            FRONT_PAGE_TITLE, POSTS_PAGE_TITLE
+        );
+    }
+
+    println!("[6/7] 🧭 メニューを作成中...");
+    let menu_items = vec![
+        MenuItemSpec {
+            title: "🏠 ホーム".to_string(),
+            page_title: FRONT_PAGE_TITLE.to_string(),
+        },
+        MenuItemSpec {
+            title: "🧭 サイトガイド".to_string(),
+            page_title: SITE_GUIDE_TITLE.to_string(),
+        },
+        MenuItemSpec {
+            title: "🛠️ サービス".to_string(),
+            page_title: "サービス".to_string(),
+        },
+        MenuItemSpec {
+            title: "🧾 投稿一覧".to_string(),
+            page_title: POSTS_PAGE_TITLE.to_string(),
+        },
+        MenuItemSpec {
+            title: "ℹ️ About Us".to_string(),
+            page_title: ABOUT_US_TITLE.to_string(),
+        },
+        MenuItemSpec {
+            title: "✉️ お問い合わせ".to_string(),
+            page_title: "お問い合わせ".to_string(),
+        },
+    ];
+
+    match ensure_primary_menu(
+        &wp_url,
+        &wp_username,
+        &wp_password,
+        &page_id_by_title,
+        PRIMARY_MENU_NAME,
+        &["primary-menu", "primary-menu-side"],
+        &menu_items,
+    )
+    .await
+    {
+        Ok(true) => println!("   ✅ メニュー作成・項目登録が完了しました"),
+        Ok(false) => {
+            warning_count += 1;
+            println!(
+                "   ⚠️  メニューAPIが利用できないためスキップしました（AFFINGER6の管理画面で手動設定してください）"
+            );
+        }
+        Err(e) => {
+            warning_count += 1;
+            println!("   ⚠️  メニュー作成に失敗しました: {}", e);
+        }
+    }
+
+    let footer_items = vec![
+        MenuItemSpec {
+            title: "About Us".to_string(),
+            page_title: ABOUT_US_TITLE.to_string(),
+        },
+        MenuItemSpec {
+            title: "サービス".to_string(),
+            page_title: "サービス".to_string(),
+        },
+        MenuItemSpec {
+            title: "Contributors募集".to_string(),
+            page_title: CONTRIBUTORS_TITLE.to_string(),
+        },
+        MenuItemSpec {
+            title: "お問い合わせ".to_string(),
+            page_title: "お問い合わせ".to_string(),
+        },
+        MenuItemSpec {
+            title: "投稿一覧".to_string(),
+            page_title: POSTS_PAGE_TITLE.to_string(),
+        },
+    ];
+
+    match ensure_primary_menu(
+        &wp_url,
+        &wp_username,
+        &wp_password,
+        &page_id_by_title,
+        FOOTER_MENU_NAME,
+        &["secondary-menu", "smartphone-footermenu"],
+        &footer_items,
+    )
+    .await
+    {
+        Ok(true) => println!("   ✅ フッターメニュー作成・項目登録が完了しました"),
+        Ok(false) => {
+            warning_count += 1;
+            println!("   ⚠️  フッターメニューAPIが利用できないためスキップしました");
+        }
+        Err(e) => {
+            warning_count += 1;
+            println!("   ⚠️  フッターメニュー作成に失敗しました: {}", e);
+        }
+    }
+
+    println!("[7/7] ✍️  ブログ記事を作成中...");
 
     let find_cat = |name: &str| -> Option<u64> {
         category_ids
@@ -301,31 +496,62 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         |name: &str| -> Option<u64> { tag_ids.iter().find(|(n, _)| n == name).map(|(_, id)| *id) };
 
     for (title, content, cats, tags) in sample_posts(&find_cat, &find_tag) {
-        if existing_post_titles.contains(&normalize_title(&title)) {
-            println!("   ♻️  「{}」既存を利用", title);
+        let normalized_title = normalize_title(&title);
+        let existing_post_id = existing_post_ids_by_title
+            .get(&normalized_title)
+            .copied()
+            .or_else(|| {
+                legacy_post_title_aliases(&title).iter().find_map(|legacy| {
+                    existing_post_ids_by_title
+                        .get(&normalize_title(legacy))
+                        .copied()
+                })
+            });
+
+        if let Some(existing_id) = existing_post_id {
+            update_post_content(
+                &wp_url,
+                &wp_username,
+                &wp_password,
+                existing_id,
+                &title,
+                &content,
+                &cats,
+                &tags,
+            )
+            .await?;
+            println!("   🔄 「{}」既存投稿を更新 (ID: {})", title, existing_id);
             sleep(Duration::from_millis(200)).await;
             continue;
         }
 
         if cats.is_empty() || tags.is_empty() {
-            return Err(std::io::Error::other(format!(
+            return Err(io::Error::other(format!(
                 "投稿「{}」に必要なカテゴリまたはタグのIDが解決できませんでした",
                 title
             ))
             .into());
         }
 
-        let categories = if cats.is_empty() { None } else { Some(cats) };
-        let tags = if tags.is_empty() { None } else { Some(tags) };
+        let categories_payload = if cats.is_empty() {
+            None
+        } else {
+            Some(cats.clone())
+        };
+        let tags_payload = if tags.is_empty() {
+            None
+        } else {
+            Some(tags.clone())
+        };
         match handler
             .create_advanced_post(PostCreateParams {
                 title: title.clone(),
-                content,
+                content: content.clone(),
                 post_type: "post".to_string(),
                 status: "publish".to_string(),
                 date: None,
-                categories,
-                tags,
+                categories: categories_payload,
+                tags: tags_payload,
                 featured_media_id: None,
                 meta: None,
             })
@@ -333,8 +559,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             Ok(post) => {
                 if let Some(post_id) = post.id {
+                    if let Err(e) = update_post_content(
+                        &wp_url,
+                        &wp_username,
+                        &wp_password,
+                        post_id,
+                        &title,
+                        &content,
+                        &cats,
+                        &tags,
+                    )
+                    .await
+                    {
+                        warning_count += 1;
+                        println!("   ⚠️  「{}」作成後のスラッグ更新失敗: {}", title, e);
+                    }
+
                     println!("   ✅ 「{}」(ID: {})", title, post_id);
-                    existing_post_titles.insert(normalize_title(&title));
+                    existing_post_ids_by_title.insert(normalized_title, post_id);
                 } else {
                     warning_count += 1;
                     println!("   ⚠️  「{}」作成成功だがIDが取得できませんでした", title);
@@ -357,7 +599,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("╔══════════════════════════════════════════════════════╗");
         println!("║  ⚠️  一部の処理で失敗が発生しました                    ║");
         println!("╚══════════════════════════════════════════════════════╝");
-        return Err(std::io::Error::other(format!(
+        return Err(io::Error::other(format!(
             "{} 件の処理失敗が発生しました。ログを確認してください。",
             warning_count
         ))
@@ -369,6 +611,192 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn normalize_title(title: &str) -> String {
     title.trim().to_lowercase()
+}
+
+fn legacy_post_title_aliases(title: &str) -> &'static [&'static str] {
+    match title {
+        "トップページ構成案を反映しました" => {
+            &["トップページ構成案（post=73）を反映しました"]
+        }
+        _ => &[],
+    }
+}
+
+fn legacy_page_title_aliases(title: &str) -> &'static [&'static str] {
+    match title {
+        POSTS_PAGE_TITLE => &["ニュース"],
+        ABOUT_US_TITLE => &["会社概要"],
+        CONTRIBUTORS_TITLE => &["採用情報"],
+        _ => &[],
+    }
+}
+
+fn post_slug_for_title(title: &str) -> Option<&'static str> {
+    match title {
+        "redring.jp を公開しました" => Some("redring-jp-launch"),
+        "トップページ構成案を反映しました" => Some("homepage-structure-update"),
+        "監査ログとセキュリティ監視を強化しました" => {
+            Some("security-monitoring-enhanced")
+        }
+        _ => None,
+    }
+}
+
+fn page_slug_for_title(title: &str) -> Option<&'static str> {
+    match title {
+        FRONT_PAGE_TITLE => Some("home"),
+        SITE_GUIDE_TITLE => Some("site-guide"),
+        "サービス" => Some("service"),
+        ABOUT_US_TITLE => Some("about-us"),
+        CONTRIBUTORS_TITLE => Some("contributors"),
+        "お問い合わせ" => Some("contact"),
+        POSTS_PAGE_TITLE => Some("blog"),
+        _ => None,
+    }
+}
+
+fn load_local_wordpress_env() -> io::Result<Option<String>> {
+    let path = env::var("WORDPRESS_ENV_FILE")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| WORDPRESS_LOCAL_ENV_FILE.to_string());
+
+    let contents = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(io::Error::other(format!(
+                "ローカル環境ファイルの読み込みに失敗しました ({}): {}",
+                path, err
+            )));
+        }
+    };
+
+    for raw_line in contents.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let Some((key_raw, value_raw)) = line.split_once('=') else {
+            continue;
+        };
+
+        let key = key_raw.trim();
+        let mut value = value_raw.trim().to_string();
+        if (value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\''))
+        {
+            value = value[1..value.len() - 1].to_string();
+        }
+
+        if key.starts_with("WORDPRESS_") && env::var(key).is_err() {
+            env::set_var(key, value);
+        }
+    }
+
+    Ok(Some(path))
+}
+
+fn resolve_wp_url() -> io::Result<String> {
+    if let Ok(url) = env::var("WORDPRESS_URL") {
+        let trimmed = url.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+    prompt_line("WORDPRESS_URL が未設定です。サイトURLを入力してください（例: https://redring.jp）")
+}
+
+fn resolve_wp_username() -> io::Result<String> {
+    if let Ok(username) = env::var("WORDPRESS_USERNAME") {
+        let trimmed = username.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+    prompt_line("WORDPRESS_USERNAME が未設定です。ユーザー名を入力してください")
+}
+
+fn resolve_wp_password() -> io::Result<String> {
+    if let Ok(password) = env::var("WORDPRESS_PASSWORD") {
+        let trimmed = password.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    if let Ok(path) = env::var("WORDPRESS_PASSWORD_FILE") {
+        let file_path = path.trim();
+        if !file_path.is_empty() {
+            let password = fs::read_to_string(file_path).map_err(|e| {
+                io::Error::other(format!(
+                    "WORDPRESS_PASSWORD_FILE の読み込みに失敗しました ({}): {}",
+                    file_path, e
+                ))
+            })?;
+            let trimmed = password.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
+            }
+        }
+    }
+
+    prompt_password_hidden(
+        "WORDPRESS_PASSWORD が未設定です。アプリケーションパスワードを入力してください",
+    )
+}
+
+fn prompt_line(prompt: &str) -> io::Result<String> {
+    print!("{}: ", prompt);
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    let value = input.trim().to_string();
+    if value.is_empty() {
+        return Err(io::Error::other("入力値が空です。"));
+    }
+    Ok(value)
+}
+
+fn prompt_password_hidden(prompt: &str) -> io::Result<String> {
+    print!("{}: ", prompt);
+    io::stdout().flush()?;
+
+    enable_raw_mode()?;
+    let mut password = String::new();
+
+    loop {
+        if let Event::Key(key_event) = read()? {
+            if key_event.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            match key_event.code {
+                KeyCode::Enter => break,
+                KeyCode::Backspace => {
+                    if !password.is_empty() {
+                        password.pop();
+                    }
+                }
+                KeyCode::Char(c) => {
+                    password.push(c);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    println!();
+
+    let trimmed = password.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(io::Error::other("パスワードが空です。"));
+    }
+    Ok(trimmed)
 }
 
 async fn fetch_all_categories(
@@ -455,31 +883,494 @@ async fn fetch_all_tags(
     Ok(all_tags)
 }
 
-/// サンプルの固定ページ: (タイトル, 本文HTML)
-///
-/// 実際のプロジェクトに合わせて内容を差し替えてください。
+async fn update_page_content(
+    base_url: &str,
+    username: &str,
+    password: &str,
+    page_id: u64,
+    title: &str,
+    content: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let url = format!("{}/wp-json/wp/v2/pages/{}", base_url, page_id);
+    let mut body = serde_json::Map::new();
+    body.insert("title".to_string(), json!(title));
+    body.insert("content".to_string(), json!(content));
+    body.insert("status".to_string(), json!("publish"));
+
+    if let Some(slug) = page_slug_for_title(title) {
+        body.insert("slug".to_string(), json!(slug));
+    }
+
+    let resp = client
+        .post(url)
+        .basic_auth(username, Some(password))
+        .json(&Value::Object(body))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(io::Error::other(format!(
+            "固定ページ更新に失敗しました (ID: {}, status: {})",
+            page_id,
+            resp.status()
+        ))
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn update_post_content(
+    base_url: &str,
+    username: &str,
+    password: &str,
+    post_id: u64,
+    title: &str,
+    content: &str,
+    categories: &[u64],
+    tags: &[u64],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let url = format!("{}/wp-json/wp/v2/posts/{}", base_url, post_id);
+    let mut body = serde_json::Map::new();
+    body.insert("title".to_string(), json!(title));
+    body.insert("content".to_string(), json!(content));
+    body.insert("status".to_string(), json!("publish"));
+    body.insert("categories".to_string(), json!(categories));
+    body.insert("tags".to_string(), json!(tags));
+
+    if let Some(slug) = post_slug_for_title(title) {
+        body.insert("slug".to_string(), json!(slug));
+    }
+
+    let resp = client
+        .post(url)
+        .basic_auth(username, Some(password))
+        .json(&Value::Object(body))
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        return Err(io::Error::other(format!(
+            "投稿更新に失敗しました (ID: {}, status: {})",
+            post_id,
+            resp.status()
+        ))
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn direct_rest_api_probe(base_url: &str) -> bool {
+    let client = Client::new();
+    let url = format!("{}/wp-json/wp/v2", base_url);
+    match client.get(url).send().await {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    }
+}
+
+async fn ensure_primary_menu(
+    base_url: &str,
+    username: &str,
+    password: &str,
+    page_id_by_title: &HashMap<String, u64>,
+    menu_name: &str,
+    location_candidates: &[&str],
+    menu_items: &[MenuItemSpec],
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let menus_url = format!("{}/wp-json/wp/v2/menus", base_url);
+
+    let list_resp = client
+        .get(&menus_url)
+        .basic_auth(username, Some(password))
+        .query(&[("per_page", "100")])
+        .send()
+        .await?;
+
+    if list_resp.status() == StatusCode::NOT_FOUND {
+        return Ok(false);
+    }
+
+    if !list_resp.status().is_success() {
+        return Err(io::Error::other(format!(
+            "メニュー一覧取得に失敗しました (status: {})",
+            list_resp.status()
+        ))
+        .into());
+    }
+
+    let menus: Vec<Value> = list_resp.json().await?;
+    let menu_id = if let Some(existing) = menus.iter().find(|m| {
+        m.get("name")
+            .and_then(|v| v.as_str())
+            .map(|name| name == menu_name)
+            .unwrap_or(false)
+    }) {
+        existing
+            .get("id")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| io::Error::other("既存メニューのIDが取得できません"))?
+    } else {
+        let create_resp = client
+            .post(&menus_url)
+            .basic_auth(username, Some(password))
+            .json(&json!({"name": menu_name}))
+            .send()
+            .await?;
+
+        if create_resp.status() == StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+
+        if !create_resp.status().is_success() {
+            return Err(io::Error::other(format!(
+                "メニュー作成に失敗しました (status: {})",
+                create_resp.status()
+            ))
+            .into());
+        }
+
+        let body: Value = create_resp.json().await?;
+        body.get("id")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| io::Error::other("作成したメニューのIDが取得できません"))?
+    };
+
+    let assign_resp = client
+        .post(format!("{}/wp-json/wp/v2/menus/{}", base_url, menu_id))
+        .basic_auth(username, Some(password))
+        .json(&json!({ "locations": location_candidates }))
+        .send()
+        .await?;
+
+    let assigned_any_location = assign_resp.status().is_success();
+
+    if !assigned_any_location {
+        let list_loc_resp = client
+            .get(format!("{}/wp-json/wp/v2/menu-locations", base_url))
+            .basic_auth(username, Some(password))
+            .send()
+            .await?;
+
+        if !list_loc_resp.status().is_success() {
+            return Ok(false);
+        }
+    }
+
+    let menu_items_url = format!("{}/wp-json/wp/v2/menu-items", base_url);
+    let existing_items_resp = client
+        .get(&menu_items_url)
+        .basic_auth(username, Some(password))
+        .query(&[("menus", menu_id.to_string())])
+        .send()
+        .await?;
+
+    if existing_items_resp.status() == StatusCode::NOT_FOUND {
+        return Ok(false);
+    }
+
+    if !existing_items_resp.status().is_success() {
+        return Err(io::Error::other(format!(
+            "メニュー項目一覧取得に失敗しました (status: {})",
+            existing_items_resp.status()
+        ))
+        .into());
+    }
+
+    let existing_items: Vec<Value> = existing_items_resp.json().await?;
+    let existing_titles: HashSet<String> = existing_items
+        .iter()
+        .filter_map(|item| item.get("title"))
+        .filter_map(|title| {
+            if title.is_object() {
+                title.get("rendered").and_then(|v| v.as_str())
+            } else {
+                title.as_str()
+            }
+        })
+        .map(normalize_title)
+        .collect();
+
+    for (idx, spec) in menu_items.iter().enumerate() {
+        if existing_titles.contains(&normalize_title(&spec.title)) {
+            continue;
+        }
+
+        let page_key = normalize_title(&spec.page_title);
+        let Some(page_id) = page_id_by_title.get(&page_key).copied() else {
+            continue;
+        };
+
+        let create_item_resp = client
+            .post(&menu_items_url)
+            .basic_auth(username, Some(password))
+            .json(&json!({
+                "menus": menu_id,
+                "title": spec.title,
+                "object": "page",
+                "object_id": page_id,
+                "type": "post_type",
+                "status": "publish",
+                "menu_order": (idx as u64) + 1
+            }))
+            .send()
+            .await?;
+
+        if create_item_resp.status() == StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+
+        if !create_item_resp.status().is_success() {
+            return Err(io::Error::other(format!(
+                "メニュー項目「{}」の作成に失敗しました (status: {})",
+                spec.title,
+                create_item_resp.status()
+            ))
+            .into());
+        }
+    }
+
+    Ok(true)
+}
+
 fn sample_pages() -> Vec<(String, String)> {
     vec![
         (
-            "About".to_string(),
+            "ホーム".to_string(),
+            r#"<!-- wp:html -->
+<style>
+body.page-id-86 #side {display: none !important;}
+body.page-id-86 #content,
+body.page-id-86 #contentInner,
+body.page-id-86 #wrapper,
+body.page-id-86 main {
+    width: 100% !important;
+    max-width: 1280px !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    float: none !important;
+}
+.rr-cad-wrap {background: radial-gradient(circle at 15% -10%, #1f2a36 0%, #121820 55%, #0b1016 100%); padding: 48px 20px; border-radius: 18px;}
+.rr-grid {max-width: 1180px; margin: 0 auto; display: grid; gap: 18px;}
+.rr-layout {position: relative; overflow: hidden; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; align-items: start; max-width: 1040px; margin: 0 auto; padding: 18px; border: 1px solid rgba(151, 179, 209, 0.24); border-radius: 20px; background: linear-gradient(180deg, rgba(18, 24, 32, 0.9) 0%, rgba(23, 31, 41, 0.96) 100%), radial-gradient(circle at 12% 14%, rgba(86, 129, 180, 0.18) 0, rgba(86, 129, 180, 0.18) 12%, transparent 13%), radial-gradient(circle at 88% 10%, rgba(118, 91, 163, 0.14) 0, rgba(118, 91, 163, 0.14) 9%, transparent 10%), repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.03) 0 1px, transparent 1px 22px); box-shadow: 0 18px 42px rgba(0, 0, 0, 0.26);}
+.rr-layout::before {content: ""; position: absolute; inset: auto -8% 10% auto; width: 180px; height: 180px; border: 1px solid rgba(130, 169, 210, 0.24); border-radius: 50%; transform: rotate(18deg); pointer-events: none;}
+.rr-layout::after {content: ""; position: absolute; inset: 12px 12px auto auto; width: 120px; height: 120px; background: linear-gradient(135deg, rgba(80, 123, 173, 0.26), rgba(80, 123, 173, 0.04)); clip-path: polygon(50% 0%, 100% 38%, 82% 100%, 18% 100%, 0% 38%); opacity: 0.8; pointer-events: none;}
+.rr-layout > * {position: relative; z-index: 1;}
+.rr-span-2 {grid-column: 1 / -1;}
+.rr-hero {position: relative; overflow: hidden; border-radius: 20px; background: linear-gradient(145deg, #182230 0%, #243449 50%, #2c4058 100%); color: #f3f7ff; padding: 44px 28px; border: 1px solid rgba(116, 146, 183, 0.35); box-shadow: 0 24px 54px rgba(0, 0, 0, 0.35);}
+.rr-hero-main {position: relative; z-index: 3; max-width: 760px;}
+.rr-kicker {font-size: 12px; letter-spacing: 0.22em; text-transform: uppercase; color: #9cb7d3;}
+.rr-title {font-size: clamp(34px, 5.2vw, 58px); line-height: 1.08; margin: 12px 0 12px; font-weight: 800;}
+.rr-sub {font-size: 16px; line-height: 1.8; color: #d4e1f2;}
+.rr-actions {margin-top: 20px; display: flex; flex-wrap: wrap; gap: 10px;}
+.rr-btn {display: inline-block; text-decoration: none; border-radius: 999px; padding: 11px 18px; font-weight: 700;}
+.rr-btn-primary {background: #007acc; color: #ffffff;}
+.rr-btn-ghost {border: 1px solid rgba(180, 204, 232, 0.6); color: #dce9f7;}
+.rr-viewport {position: absolute; right: 18px; bottom: 10px; width: min(44%, 420px); opacity: 0.95; z-index: 2;}
+.rr-wire {stroke: #79a8d8; stroke-width: 1.2; fill: none;}
+.rr-wire-strong {stroke: #9fd4ff; stroke-width: 1.8; fill: rgba(78, 121, 172, 0.12);}
+.rr-section {background: rgba(16, 22, 30, 0.58); border: 1px solid rgba(151, 179, 209, 0.28); border-radius: 18px; padding: 18px; height: 100%; box-sizing: border-box; backdrop-filter: blur(10px); box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);}
+.rr-section h2 {margin: 0 0 10px; font-size: 22px; color: #dbe7f6;}
+.rr-section ul {margin: 6px 0 0; padding-left: 20px; color: #c3d2e3; line-height: 1.6;}
+.rr-section p {margin: 0; color: #c3d2e3;}
+.rr-links {display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px; margin-top: 14px;}
+.rr-link {display: block; background: rgba(31, 43, 57, 0.7); border: 1px solid rgba(166, 191, 217, 0.38); border-radius: 10px; padding: 10px 12px; color: #e6f0fa; text-decoration: none; font-weight: 700;}
+.rr-link:hover {background: rgba(43, 58, 77, 0.9);}
+.rr-post-grid {display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 12px;}
+.rr-post {display: block; background: rgba(24, 34, 46, 0.72); border: 1px solid rgba(166, 191, 217, 0.32); border-radius: 12px; padding: 14px; color: #e6f0fa; text-decoration: none; min-height: 100%; box-sizing: border-box;}
+.rr-post:hover {background: rgba(39, 54, 72, 0.92);}
+.rr-post-title {font-weight: 800; margin-bottom: 6px;}
+.rr-tag-map {display: flex; flex-wrap: wrap; gap: 8px;}
+.rr-tag {display: inline-block; background: rgba(41, 58, 78, 0.78); border: 1px solid rgba(183, 205, 229, 0.34); border-radius: 999px; padding: 7px 12px; color: #e6f0fa; text-decoration: none; font-weight: 700; font-size: 13px;}
+.rr-techline {display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-top: 14px;}
+.rr-chip {border: 1px solid #c8d2e1; border-radius: 999px; padding: 10px 14px; font-size: 13px; background: #f7fafc; color: #253449;}
+@keyframes rr-spin {from {transform: rotate(0deg);} to {transform: rotate(360deg);}}
+@media (max-width: 1080px) {.rr-layout {max-width: none;}}
+@media (max-width: 920px) {.rr-layout {grid-template-columns: 1fr;}}
+@media (max-width: 920px) {.rr-viewport {position: static; width: 100%; margin-top: 18px;}}
+@media (max-width: 760px) {.rr-hero {padding: 34px 18px;}}
+</style>
+
+<div class="rr-cad-wrap">
+  <div class="rr-grid">
+    <section class="rr-hero">
+      <div class="rr-hero-main">
+        <p class="rr-kicker">RedRing CAD-Inspired Experience</p>
+        <h1 class="rr-title">CAD設計を、正確に、速く、再利用しやすく。</h1>
+                <p class="rr-sub">RedRing は、CAD作業の手戻りを減らし、設計を再利用しやすくすることを目指しています。実務で使える改善を積み重ね、継続的に品質と運用性を高めます。</p>
+        <div class="rr-actions">
+                    <a class="rr-btn rr-btn-primary" href="/service/">🛠️ 提供サービスを見る</a>
+                    <a class="rr-btn rr-btn-ghost" href="/category/redring%E6%80%9D%E6%83%B3/">📐 設計思想を見る</a>
+        </div>
+      </div>
+
+            <svg class="rr-viewport" viewBox="0 0 420 280" role="img" aria-label="CAD style wireframe">
+                <defs>
+                    <pattern id="rr-grid-p" width="18" height="18" patternUnits="userSpaceOnUse">
+                        <path d="M 18 0 L 0 0 0 18" fill="none" stroke="rgba(143,176,211,0.22)" stroke-width="1"/>
+                    </pattern>
+                </defs>
+                <rect x="0" y="0" width="420" height="280" fill="url(#rr-grid-p)" rx="12"/>
+                <polyline class="rr-wire" points="26,214 96,154 188,162 266,126 362,136"/>
+                <polyline class="rr-wire" points="26,240 98,176 194,186 274,148 374,164"/>
+                <polygon class="rr-wire-strong" points="120,146 192,110 270,150 196,186"/>
+                <polygon class="rr-wire" points="192,110 192,62 270,102 270,150"/>
+                <polygon class="rr-wire" points="120,146 120,98 192,62 192,110"/>
+                <circle cx="300" cy="82" r="20" class="rr-wire"/>
+                <line x1="300" y1="62" x2="300" y2="102" class="rr-wire"/>
+                <line x1="280" y1="82" x2="320" y2="82" class="rr-wire"/>
+            </svg>
+    </section>
+
+    <div class="rr-layout">
+        <section class="rr-section">
+            <h2>カテゴリナビゲーション</h2>
+            <ul>
+                <li><a href="/category/%e5%ae%9f%e8%a3%85%e8%a8%98%e9%8c%b2/" style="color: #17324f; text-decoration: none; font-weight: 700;">📝 実装記録</a> - 3DCAD・幾何処理の技術ブログ</li>
+                <li><a href="/category/redring%E6%80%9D%E6%83%B3/" style="color: #17324f; text-decoration: none; font-weight: 700;">💡 RedRing思想</a> - 設計方針・アーキテクチャ・理念</li>
+                <li><a href="/category/%e3%81%8a%e7%9f%a5%e3%82%89%e3%81%9b/" style="color: #17324f; text-decoration: none; font-weight: 700;">📢 お知らせ</a> - サイト更新・リリース情報</li>
+            </ul>
+        </section>
+
+        <section class="rr-section">
+            <h2>RedRing思想</h2>
+            <p style="color: #20374f; line-height: 1.8;">Geometry Must Be Explicit. Architecture Must Be Modular.（幾何は明示的に、アーキテクチャはモジュール性を）という設計思想のもと、3DCAD・幾何処理・システム設計の知見を公開しています。</p>
+            <div style="margin-top: 14px;">
+                <a class="rr-link" href="/category/redring%E6%80%9D%E6%83%B3/" style="display: inline-block;">📐 RedRing思想カテゴリへ</a>
+            </div>
+        </section>
+
+        <section class="rr-section">
+            <h2>タグ・分類マップ</h2>
+            <div class="rr-tag-map">
+                <a class="rr-tag" href="/tag/mcp/">#MCP</a>
+                <a class="rr-tag" href="/tag/rust/">#Rust</a>
+                <a class="rr-tag" href="/tag/wordpress/">#WordPress</a>
+                <a class="rr-tag" href="/tag/%e3%82%bb%e3%82%ad%e3%83%a5%e3%83%aa%e3%83%86%e3%82%a3/">#セキュリティ</a>
+                <a class="rr-tag" href="/tag/%e7%94%9f%e6%88%90ai/">#生成AI</a>
+                <a class="rr-tag" href="/tag/%e9%81%8b%e7%94%a8%e8%87%aa%e5%8b%95%e5%8c%96/">#運用自動化</a>
+                <a class="rr-tag" href="/tag/%e6%a7%8b%e9%80%a0%e7%be%8e/">#構造美</a>
+                <a class="rr-tag" href="/tag/github/">#GitHub</a>
+            </div>
+        </section>
+
+        <section class="rr-section rr-span-2">
+            <h2>GitHub・開発リンク</h2>
+            <div class="rr-links">
+                <a class="rr-link" href="https://github.com/RedRing2020/RedRing" target="_blank" rel="noopener noreferrer">🔷 RedRing Repository</a>
+                <a class="rr-link" href="https://github.com/n-takatsu/mcp-rs" target="_blank" rel="noopener noreferrer">⚙️ mcp-rs（サイト構築基盤）</a>
+                <a class="rr-link" href="https://redring.jp/category/%e5%ae%9f%e8%a3%85%e8%a8%98%e9%8c%b2/" target="_blank" rel="noopener noreferrer">🧾 実装記録カテゴリー</a>
+            </div>
+        </section>
+    </div>
+
+  </div>
+</div>
+<!-- /wp:html -->"#
+                .to_string(),
+        ),
+        (
+            SITE_GUIDE_TITLE.to_string(),
             r#"<!-- wp:paragraph -->
-<p>このサイトについての説明をここに記載します。</p>
+<p>このページは、redring.jp を初めて訪れる方に向けた「サイトの使い方ガイド」です。3DCAD 開発を主軸にしつつ、周辺の自動化や実装基盤も含めて、サイトで得られる価値・主要導線・更新方針を短く案内します。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>1. このサイトで得られる価値</h3>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul>
+    <li>3DCAD、幾何処理、設計自動化を中心に、実装と運用の知見を実例ベースで公開します。</li>
+    <li>主軸は 3DCAD 開発ですが、関連する実装基盤として mcp-rs や WordPress 連携も紹介します。</li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:heading {"level":3} -->
+<h3>2. 主要コンテンツへの入口</h3>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul>
+    <li>サイト全体の主要導線は、グローバルメニューから利用してください。</li>
+    <li>最新情報は「投稿一覧」、3DCAD を含む開発記録は「実装記録」カテゴリから確認できます。</li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:heading {"level":3} -->
+<h3>3. 更新方針</h3>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul>
+    <li>小さく公開し、検証しながら継続的に改善します。</li>
+    <li>内容が固まるまでは、要点を優先して段階的に追記します。</li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p>詳細な実装背景や設計メモは、必要に応じて個別の記事・ドキュメントで公開します。</p>
 <!-- /wp:paragraph -->"#
                 .to_string(),
         ),
         (
-            "Contact".to_string(),
+            "サービス".to_string(),
+            r#"<!-- wp:heading {"level":2} -->
+<h2>提供サービス</h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul>
+    <li>📐 3DCAD アプリケーション設計・開発支援</li>
+    <li>🧩 幾何処理・設計自動化ワークフローの実装支援</li>
+    <li>⚙️ 関連基盤としての mcp-rs / WordPress 連携・運用支援</li>
+</ul>
+<!-- /wp:list -->"#
+                .to_string(),
+        ),
+        (
+            ABOUT_US_TITLE.to_string(),
             r#"<!-- wp:paragraph -->
-<p>お問い合わせ方法についての説明をここに記載します。</p>
+<p>RedRing の背景、取り組み方、公開方針をまとめています。現時点では法人紹介ではなく、3DCAD・幾何処理・設計自動化に取り組む活動の概要ページとして運用します。</p>
+<!-- /wp:paragraph -->"#
+                .to_string(),
+        ),
+        (
+            CONTRIBUTORS_TITLE.to_string(),
+            r#"<!-- wp:paragraph -->
+<p>RedRing では、GitHub 上で実装・検証・ドキュメント整備に参加してくれる contributors を歓迎しています。興味のある方は、リポジトリの Issue・Pull Request・ドキュメント改善から参加してください。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul>
+    <li><a href="https://github.com/RedRing2020/RedRing" target="_blank" rel="noreferrer noopener">RedRing Repository</a></li>
+    <li><a href="https://github.com/n-takatsu/mcp-rs" target="_blank" rel="noreferrer noopener">mcp-rs Repository</a></li>
+    <li>まずは README、Issue、既存ドキュメントの改善提案からでも歓迎します。</li>
+</ul>
+<!-- /wp:list -->"#
+                .to_string(),
+        ),
+        (
+            "お問い合わせ".to_string(),
+            r#"<!-- wp:paragraph -->
+<p>案件相談やお見積り、協業のご相談はフォームからお問い合わせください。</p>
+<!-- /wp:paragraph -->"#
+                .to_string(),
+        ),
+        (
+            POSTS_PAGE_TITLE.to_string(),
+            r#"<!-- wp:paragraph -->
+    <p>このページでは、redring.jp のすべての投稿・ブログ記事が時系列で一覧表示されます。最新情報から過去の記事まで、カテゴリやタグから検索・フィルタリングも可能です。</p>
 <!-- /wp:paragraph -->"#
                 .to_string(),
         ),
     ]
 }
 
-/// サンプルのブログ記事: (タイトル, 本文HTML, カテゴリID一覧, タグID一覧)
-///
-/// 実際のプロジェクトに合わせて内容を差し替えてください。
 fn sample_posts<F, G>(find_cat: &F, find_tag: &G) -> Vec<(String, String, Vec<u64>, Vec<u64>)>
 where
     F: Fn(&str) -> Option<u64>,
@@ -487,38 +1378,145 @@ where
 {
     vec![
         (
-            "サイトをオープンしました".to_string(),
+            "redring.jp を公開しました".to_string(),
             r#"<!-- wp:paragraph -->
-<p>ようこそ。このサイトは <a href="https://github.com/rireki-ai/mcp-rs">mcp-rs</a> を使って自動構築されました。</p>
+<p>redring.jp を公開しました。3DCAD 開発を主軸に、関連する設計・実装の記録を段階的に公開していきます。</p>
 <!-- /wp:paragraph -->"#
                 .to_string(),
-            vec![find_cat("お知らせ")]
-                .into_iter()
-                .flatten()
-                .collect(),
-            vec![find_tag("リリース"), find_tag("オープンソース")]
+            vec![find_cat("ウェブサイト")].into_iter().flatten().collect(),
+            vec![
+                find_tag("RedRing"),
+                find_tag("WordPress"),
+                find_tag("サイト運用"),
+                find_tag("構造美"),
+            ]
                 .into_iter()
                 .flatten()
                 .collect(),
         ),
         (
-            "mcp-rs で WordPress を自動構築する方法".to_string(),
+            "トップページ構成案を反映しました".to_string(),
             r#"<!-- wp:paragraph -->
-<p>mcp-rs の WordPress ツール群を使うと、カテゴリ・タグ・ページ・記事をコードから一括生成できます。</p>
+<p>トップページ構成案をもとに、初回公開後の実運用で見えてきた課題を反映した更新を行いました。今回の目的は、訪問直後に「このサイトで何が得られるか」を短時間で把握できる状態をつくることです。</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:code -->
-<pre class="wp-block-code"><code class="language-bash">export WORDPRESS_URL="https://your-site.example.com"
-export WORDPRESS_USERNAME="your_username"
-export WORDPRESS_PASSWORD="your_app_password"
-cargo run --example wordpress_site_builder_demo</code></pre>
-<!-- /wp:code -->"#
+<!-- wp:heading {"level":3} -->
+<h3>今回の更新背景</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>公開直後の構成では、導線の重複やメニュー項目の混在により、初見ユーザーが主要コンテンツへ到達するまでに迷いやすい箇所がありました。特に、ヘッダー導線とサイドバー導線の役割分担を明確にする必要がありました。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>主な変更内容</h3>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul>
+    <li>ヒーロー領域のメッセージを中心に、サイトの提供価値を先頭で明確化。</li>
+    <li>カテゴリ導線とタグ分類マップを整理し、技術記事への到達経路を短縮。</li>
+    <li>GitHubリンクを独立セクション化し、実装情報へのアクセスを強化。</li>
+    <li>メニュー重複を解消し、主要導線をホーム／サイトガイド／サービス／投稿一覧／About Us／お問い合わせへ統一。</li>
+    <li>投稿一覧ページは本文説明と実記事表示の役割を整理し、閲覧時のノイズを削減。</li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:heading {"level":3} -->
+<h3>更新後に期待する効果</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>サイト内回遊の起点が明確になり、初見ユーザーは「どこを見ればよいか」を短時間で判断しやすくなります。また、運用側としても導線の責務が整理され、今後の改修時に影響範囲を限定しやすくなります。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>今後の方針</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>今後は、アクセス状況と閲覧行動を見ながら、カテゴリごとの導線改善と記事アーカイブの見つけやすさを段階的に強化します。大きな改修は避けつつ、実運用に合わせた小さな改善を継続していきます。</p>
+<!-- /wp:paragraph -->
+"#
                 .to_string(),
-            vec![find_cat("技術ブログ")]
+            vec![find_cat("ウェブサイト")].into_iter().flatten().collect(),
+            vec![
+                find_tag("WordPress"),
+                find_tag("サイト運用"),
+                find_tag("UI改善"),
+                find_tag("導線整理"),
+            ]
                 .into_iter()
                 .flatten()
                 .collect(),
-            vec![find_tag("Rust"), find_tag("チュートリアル")]
+        ),
+        (
+            "監査ログとセキュリティ監視を強化しました".to_string(),
+            r#"<!-- wp:paragraph -->
+<p>監査ログとセキュリティ監視の運用を強化しました。この記事は、MCPサーバー経由でWordPressを更新・確認する運用担当者を主な対象にしています。単に「記録する」だけでなく、あとから追跡できる粒度で変更内容を残し、異常に気づける状態を優先しています。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>この投稿は、mcp-rs の WordPress デモ構築部分を実例として見せるために公開しています。redring.jp をどのように立ち上げ、どのように運用情報を残すかを示すことで、コード側のデモと実際のサイト運用をつなげる狙いがあります。詳しくは <a href="https://github.com/n-takatsu/mcp-rs" target="_blank" rel="noreferrer noopener">mcp-rs のリポジトリ</a> と <a href="https://redring.jp/" target="_blank" rel="noreferrer noopener">redring.jp</a> を参照してください。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>対象読者</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>この内容は、MCPサーバーを使ってWordPressの更新や点検を自動化している人、あるいは人手での更新と自動処理を併用しながらサイト運用を進めている人を想定しています。サイト公開後の変更履歴を残したい、障害時に原因をすばやく追いたい、という運用寄りの課題に向けた話です。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>見直しの背景</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>サイト公開後は、コンテンツ更新や設定変更が少しずつ増えていきます。そのため、どの変更が、いつ、誰によって行われ、結果として何が変わったのかを後から把握できる形にしておく必要がありました。</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3>監査ログの粒度</h3>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul>
+    <li>設定更新は、変更前後の差分が追える粒度で記録します。</li>
+    <li>投稿や固定ページの更新は、公開状態と更新対象が分かる形で残します。</li>
+    <li>カテゴリやタグの再分類は、導線設計への影響を確認できるように扱います。</li>
+    <li>メニューやフロントページ設定の変更は、ユーザー体験に直結するため重点的に追跡します。</li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:heading {"level":3} -->
+<h3>監視の観点</h3>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul>
+    <li>REST API の失敗や権限エラーを早めに検知します。</li>
+    <li>想定外の更新や差分が出たときに原因を追跡しやすくします。</li>
+    <li>公開後の運用で継続的に確認すべき項目を絞り込みます。</li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:heading {"level":3} -->
+<h3>運用上の効果</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>この見直しによって、変更時の確認コストを下げながら、問題が起きたときの切り分けを速くできます。公開直後の段階でも、将来の自動アラートや監査運用へつなげやすい土台になります。</p>
+<!-- /wp:paragraph -->"#
+                .to_string(),
+            vec![find_cat("技術信頼性")].into_iter().flatten().collect(),
+            vec![
+                find_tag("セキュリティ"),
+                find_tag("監査ログ"),
+                find_tag("監視"),
+                find_tag("運用自動化"),
+                find_tag("WordPress"),
+            ]
                 .into_iter()
                 .flatten()
                 .collect(),

--- a/examples/wordpress_site_builder_demo.rs
+++ b/examples/wordpress_site_builder_demo.rs
@@ -510,14 +510,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         if let Some(existing_id) = existing_post_id {
             update_post_content(
-                &wp_url,
-                &wp_username,
-                &wp_password,
-                existing_id,
-                &title,
-                &content,
-                &cats,
-                &tags,
+                PostUpdateBuilder::new(&wp_url, existing_id)
+                    .credentials(&wp_username, &wp_password)
+                    .title(&title)
+                    .content(&content)
+                    .categories(&cats)
+                    .tags(&tags),
             )
             .await?;
             println!("   🔄 「{}」既存投稿を更新 (ID: {})", title, existing_id);
@@ -560,14 +558,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(post) => {
                 if let Some(post_id) = post.id {
                     if let Err(e) = update_post_content(
-                        &wp_url,
-                        &wp_username,
-                        &wp_password,
-                        post_id,
-                        &title,
-                        &content,
-                        &cats,
-                        &tags,
+                        PostUpdateBuilder::new(&wp_url, post_id)
+                            .credentials(&wp_username, &wp_password)
+                            .title(&title)
+                            .content(&content)
+                            .categories(&cats)
+                            .tags(&tags),
                     )
                     .await
                     {
@@ -921,32 +917,78 @@ async fn update_page_content(
     Ok(())
 }
 
-async fn update_post_content(
-    base_url: &str,
-    username: &str,
-    password: &str,
+struct PostUpdateBuilder {
+    base_url: String,
     post_id: u64,
-    title: &str,
-    content: &str,
-    categories: &[u64],
-    tags: &[u64],
-) -> Result<(), Box<dyn std::error::Error>> {
-    let client = Client::new();
-    let url = format!("{}/wp-json/wp/v2/posts/{}", base_url, post_id);
-    let mut body = serde_json::Map::new();
-    body.insert("title".to_string(), json!(title));
-    body.insert("content".to_string(), json!(content));
-    body.insert("status".to_string(), json!("publish"));
-    body.insert("categories".to_string(), json!(categories));
-    body.insert("tags".to_string(), json!(tags));
+    username: String,
+    password: String,
+    title: String,
+    content: String,
+    categories: Vec<u64>,
+    tags: Vec<u64>,
+}
 
-    if let Some(slug) = post_slug_for_title(title) {
+impl PostUpdateBuilder {
+    fn new(base_url: &str, post_id: u64) -> Self {
+        Self {
+            base_url: base_url.to_string(),
+            post_id,
+            username: String::new(),
+            password: String::new(),
+            title: String::new(),
+            content: String::new(),
+            categories: Vec::new(),
+            tags: Vec::new(),
+        }
+    }
+
+    fn credentials(mut self, username: &str, password: &str) -> Self {
+        self.username = username.to_string();
+        self.password = password.to_string();
+        self
+    }
+
+    fn title(mut self, title: &str) -> Self {
+        self.title = title.to_string();
+        self
+    }
+
+    fn content(mut self, content: &str) -> Self {
+        self.content = content.to_string();
+        self
+    }
+
+    fn categories(mut self, categories: &[u64]) -> Self {
+        self.categories = categories.to_vec();
+        self
+    }
+
+    fn tags(mut self, tags: &[u64]) -> Self {
+        self.tags = tags.to_vec();
+        self
+    }
+}
+
+async fn update_post_content(builder: PostUpdateBuilder) -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let url = format!(
+        "{}/wp-json/wp/v2/posts/{}",
+        builder.base_url, builder.post_id
+    );
+    let mut body = serde_json::Map::new();
+    body.insert("title".to_string(), json!(builder.title));
+    body.insert("content".to_string(), json!(builder.content));
+    body.insert("status".to_string(), json!("publish"));
+    body.insert("categories".to_string(), json!(builder.categories));
+    body.insert("tags".to_string(), json!(builder.tags));
+
+    if let Some(slug) = post_slug_for_title(&builder.title) {
         body.insert("slug".to_string(), json!(slug));
     }
 
     let resp = client
         .post(url)
-        .basic_auth(username, Some(password))
+        .basic_auth(&builder.username, Some(&builder.password))
         .json(&Value::Object(body))
         .send()
         .await?;
@@ -954,7 +996,7 @@ async fn update_post_content(
     if !resp.status().is_success() {
         return Err(io::Error::other(format!(
             "投稿更新に失敗しました (ID: {}, status: {})",
-            post_id,
+            builder.post_id,
             resp.status()
         ))
         .into());


### PR DESCRIPTION
This PR documents the redring.jp WordPress demo site in both READMEs, adds reciprocal links between the repo and the live site, and refines the demo posts used by `examples/wordpress_site_builder_demo.rs`.

Changes:
- Add a live demo site note to `README.md` and `README.ja.md`
- Clarify the `監査ログとセキュリティ監視を強化しました` article with its intended audience and demo-site background
- Reclassify the demo posts/categories/tags for the redring.jp site
- Ignore `.env.wordpress.local` in git

The branch has already been pushed as `feature/homepage-54-alignment`.